### PR TITLE
Fixed #111 | Limited Card Usages in Puzzle Mode

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable Shared Data.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable Shared Data.asset
@@ -144,7 +144,8 @@ MonoBehaviour:
     m_Key: line:02e9f33
     m_Metadata:
       m_Items:
-      - rid: 1920193901558497366
+      - rid: -2
+      - rid: 5149545320594538566
   - m_Id: 4026151577800704
     m_Key: line:0c4b355
     m_Metadata:
@@ -530,7 +531,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items:
       - rid: 1920193901558497443
-      - rid: 1920193879345987697
+      - rid: -2
   - m_Id: 3730320131665920
     m_Key: line:7ca033d8
     m_Metadata:
@@ -671,6 +672,146 @@ MonoBehaviour:
     m_Metadata:
       m_Items:
       - rid: 166915940083302427
+  - m_Id: 4125918963728384
+    m_Key: line:ed8c38a1
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538567
+  - m_Id: 4125918988894208
+    m_Key: line:7bbc3fd6
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538568
+  - m_Id: 4125918988894209
+    m_Key: line:d8295b48
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538569
+  - m_Id: 4125918988894210
+    m_Key: line:4e195c3f
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538570
+  - m_Id: 4125918988894211
+    m_Key: line:f44855a6
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538571
+  - m_Id: 4125918988894212
+    m_Key: line:627852d1
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538572
+  - m_Id: 4125918988894213
+    m_Key: line:f365ed41
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538573
+  - m_Id: 4125918988894214
+    m_Key: line:6555ea36
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538574
+  - m_Id: 4125918988894215
+    m_Key: line:0ef1aec8
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538575
+  - m_Id: 4125918988894216
+    m_Key: line:98c1a9bf
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538576
+  - m_Id: 4125918988894217
+    m_Key: line:2290a026
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538577
+  - m_Id: 4125918988894218
+    m_Key: line:b4a0a751
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538578
+  - m_Id: 4125918988894219
+    m_Key: line:1735c3cf
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538579
+  - m_Id: 4125918988894220
+    m_Key: line:8105c4b8
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538580
+  - m_Id: 4125918988894221
+    m_Key: line:3b54cd21
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538581
+  - m_Id: 4125918988894222
+    m_Key: line:ad64ca56
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538582
+  - m_Id: 4125918988894223
+    m_Key: line:3c7975c6
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538583
+  - m_Id: 4125918988894224
+    m_Key: line:aa4972b1
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538584
+  - m_Id: 4125918988894225
+    m_Key: line:4fc0b5d1
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538585
+  - m_Id: 4125918988894226
+    m_Key: line:d9f0b2a6
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538586
+  - m_Id: 4125918988894227
+    m_Key: line:63a1bb3f
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538587
+  - m_Id: 4125918988894228
+    m_Key: line:f591bc48
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538588
+  - m_Id: 4125918988894229
+    m_Key: line:5604d8d6
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538589
+  - m_Id: 4125918988894230
+    m_Key: line:c034dfa1
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538590
+  - m_Id: 4125918988894231
+    m_Key: line:7a65d638
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538591
+  - m_Id: 4125918988894232
+    m_Key: line:ec55d14f
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538592
+  - m_Id: 4125918988894233
+    m_Key: line:7d486edf
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538593
+  - m_Id: 4125918988894234
+    m_Key: line:eb7869a8
+    m_Metadata:
+      m_Items:
+      - rid: 5149545320594538594
   m_Metadata:
     m_Items: []
   m_KeyGenerator:
@@ -678,7 +819,8 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 1920193901558497366
+    - rid: -2
+      type: {class: , ns: , asm: }
     - rid: 166915940083302400
       type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
       data:
@@ -818,11 +960,6 @@ MonoBehaviour:
       type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
       data:
         nodeName: Penguin
-        tags: []
-    - rid: 1920193879345987670
-      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
-      data:
-        nodeName: Judith
         tags: []
     - rid: 1920193901558497367
       type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
@@ -1205,6 +1342,151 @@ MonoBehaviour:
         nodeName: Penguin
         tags: []
     - rid: 1920193901558497443
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538566
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Judith
+        tags: []
+    - rid: 5149545320594538567
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538568
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538569
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538570
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538571
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538572
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538573
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538574
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538575
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538576
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538577
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538578
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538579
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538580
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538581
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538582
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538583
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538584
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538585
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538586
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538587
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538588
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538589
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538590
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538591
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538592
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538593
+      type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
+      data:
+        nodeName: Penguin
+        tags: []
+    - rid: 5149545320594538594
       type: {class: LineMetadata, ns: Yarn.Unity.UnityLocalization, asm: YarnSpinner.Unity}
       data:
         nodeName: Penguin

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable_en.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable_en.asset
@@ -583,6 +583,124 @@ MonoBehaviour:
       one day whether you like it or not!)'
     m_Metadata:
       m_Items: []
+  - m_Id: 4125918963728384
+    m_Localized: 'Penguin NPC: Brrrrr! (What are you doing here?!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894208
+    m_Localized: 'Sky: Uh, what?'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894209
+    m_Localized: 'Penguin: Brrrrrrrrrrrrrr! (You shall meet your End!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894210
+    m_Localized: "Sky: Sorry, I don\u2019t speak penguin."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894211
+    m_Localized: 'Penguin: Br! (Fear me human)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894212
+    m_Localized: 'Sky: It was probably just trying to say hello!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894213
+    m_Localized: 'Penguin NPC: Noot Noot! (Nothing on this island is as cold as my
+      soul)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894214
+    m_Localized: 'Sky: What a cute little guy.'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894215
+    m_Localized: 'Penguin NPC: Noot! Noot! (Get off the island while you still can!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894216
+    m_Localized: 'Sky: Well, bye!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894217
+    m_Localized: 'Penguin NPC: Nooot! Nooot! (Noooo! The Beast will feast on your
+      bones)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894218
+    m_Localized: "Penguin NPC: Gak! (I\u2019m training to be able to fly!)"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894219
+    m_Localized: "Sky: Sorry little buddy, but penguins can\u2019t fly."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894220
+    m_Localized: "Penguin NPC: Gaaak! (Coward! I\u2019ll show you!)"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894221
+    m_Localized: 'Penguin NPC: Quank! (Where is that Bastard!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894222
+    m_Localized: 'Sky: Aww! Look at this little cutie!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894223
+    m_Localized: "Penguin NPC: Quack!(I\u2019m looking for that bastard, Marvin!)"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894224
+    m_Localized: 'Sky: Aw so cute wiggling their little flippers.'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894225
+    m_Localized: 'Penguin NPC: Quank! (That bastard tossed my child over the Island!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894226
+    m_Localized: 'Sky: Aww well bye little guy.'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894227
+    m_Localized: 'Penguin NPC: Quank! Quank! Quank!(Wait where are you going! Come
+      Back! HELP MY CHILD!!!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894228
+    m_Localized: 'Penguin NPC: Brrr (You are not a penguin, get out!)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894229
+    m_Localized: "Sky: Oh my gosh you\u2019re such a cutie patootie!"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894230
+    m_Localized: "Penguin NPC: Brr! (I\u2019ll rip your face clean off if you take
+      another step!)"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894231
+    m_Localized: "Sky: Awww you\u2019re just as sweet as you are adorable!"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894232
+    m_Localized: 'Penguin NPC: Squawk! (Why do we live just to die?)'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894233
+    m_Localized: 'Sky: Awww look at this cute little fella! Not a single thought
+      behind those eyes!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 4125918988894234
+    m_Localized: 'Penguin NPC: Squuuaaawwk! (Your story will turn its final page
+      one day whether you like it or not!)'
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
@@ -4273,8 +4273,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c25cdba096906e54bb7d84f6b69f698b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
-  startingMana: 5
-  manaLabel: {fileID: 4244620660118580199}
+  startingMana: 10
+  moveLeftUses: 2
+  moveRightUses: 2
+  moveForwardUses: 2
+  moveBackUses: 2
 --- !u!1 &8066876773405094797
 GameObject:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/UI/ReturnToSplashPage.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/UI/ReturnToSplashPage.prefab
@@ -368,7 +368,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &7688672782111972531
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
@@ -11,20 +11,14 @@ using TMPro;
 public class ResourceManager : MonoBehaviour
 {
     public static ResourceManager Instance;
-    
+
     public int startingMana = 5;
     private int currentMana;
-    
-    [Title("Resource Data")]
-    [EnumToggleButtons, HideLabel]
-    [InfoBox("Attach the resource data related to the given puzzle.")]
-    public TMP_Text manaLabel;
-    
-    // TODO: Add movement card data here as well? Right now I'm just
-    //       building out a functional version, but want to refactor
-    //       code later on for clarity and reusability. Perhaps there
-    //       should be a separate class for textual UI updates. Let
-    //       me know your thoughts -- Nikki
+
+    public int moveLeftUses = 3;
+    public int moveRightUses = 3;
+    public int moveForwardUses = 3;
+    public int moveBackUses = 3;
 
     void Awake()
     {
@@ -34,32 +28,66 @@ public class ResourceManager : MonoBehaviour
     void Start()
     {
         currentMana = startingMana;
-        Debug.Log("ResourceManager.cs >> Starting Mana: " + currentMana);
-        UpdateManaText(currentMana);
+        Debug.Log("Starting Mana: " + currentMana);
     }
 
-    public bool UseMana(int amount)
+    public bool UseMove(string moveType)
     {
-        
-        if (currentMana < amount)
+        if (currentMana <= 0)
         {
-            Debug.Log("ResourceManager.cs >> No mana to move.");
+            Debug.Log("No mana to move");
             return false;
         }
 
-        currentMana -= amount;
-        UpdateManaText(currentMana);
-        Debug.Log("ResourceManager.cs >> Mana remaining after move: " + currentMana);
+        switch (moveType)
+        {
+            case "Left":
+                if (moveLeftUses <= 0)
+                {
+                    Debug.Log("No Left card uses remaining");
+                    return false;
+                }
+                moveLeftUses--;
+                break;
+
+            case "Right":
+                if (moveRightUses <= 0)
+                {
+                    Debug.Log("No Right card uses remaining");
+                    return false;
+                }
+                moveRightUses--;
+                break;
+
+            case "Forward":
+                if (moveForwardUses <= 0)
+                {
+                    Debug.Log("No Forward card uses remaining");
+                    return false;
+                }
+                moveForwardUses--;
+                break;
+
+            case "Back":
+                if (moveBackUses <= 0)
+                {
+                    Debug.Log("No Back card uses remaining");
+                    return false;
+                }
+                moveBackUses--;
+                break;
+        }
+
+        currentMana--;
+
+        Debug.Log("Mana remaining: " + currentMana);
+        Debug.Log("Card used: " + moveType);
+
         return true;
     }
 
     public int GetMana()
     {
         return currentMana;
-    }
-    
-    private void UpdateManaText(int amount)
-    {
-        manaLabel.text = $"Mana\n{amount}";
     }
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
@@ -56,15 +56,6 @@ public class SelectableTile : MonoBehaviour
             return;
         }
 
-        // Valid move: deduct mana
-        if (!ResourceManager.Instance.UseMana(1))
-        {
-            Debug.Log("Not enough mana to move");
-            return;
-        }
-
-        Debug.Log("Move allowed – mana deducted");
-
         GridManager.Instance.ClearCell(gridX, gridZ);
 
         gridX = newX;

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
@@ -80,6 +80,8 @@ public class TileSelector : MonoBehaviour
         // not on the selected tile before trying to move it.
         if (selectedTile == null) return;
         if (PlayerOnSelectedCube()) return;
+
+        if (!ResourceManager.Instance.UseMove("Right")) return;
         
         selectedTile.TryMove(1, 0); // moves right
     }
@@ -90,6 +92,8 @@ public class TileSelector : MonoBehaviour
         // not on the selected tile before trying to move it.
         if (selectedTile == null) return;
         if (PlayerOnSelectedCube()) return;
+
+        if (!ResourceManager.Instance.UseMove("Left")) return;
         
         selectedTile.TryMove(-1, 0); // moves left
     }
@@ -100,6 +104,8 @@ public class TileSelector : MonoBehaviour
         // not on the selected tile before trying to move it.
         if (selectedTile == null) return;
         if (PlayerOnSelectedCube()) return;
+
+        if (!ResourceManager.Instance.UseMove("Forward")) return;
         
         selectedTile.TryMove(0, 1); // moves forward
     }
@@ -110,6 +116,8 @@ public class TileSelector : MonoBehaviour
         // not on the selected tile before trying to move it.
         if (selectedTile == null) return;
         if (PlayerOnSelectedCube()) return;
+
+        if (!ResourceManager.Instance.UseMove("Back")) return;
         
         selectedTile.TryMove(0, -1); // moves back
     }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/111-add-movement-card-uses-to-resource-system`](https://github.com/Precipice-Games/untitled-26/tree/issue/111-add-movement-card-uses-to-resource-system) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR is fixes #111, which is a sub-issue to [#109](https://github.com/Precipice-Games/untitled-26/issues/109).

### In-depth Details
- We are now able to set up a number for however many usages we want for each card.
- Need to display this through the UI somehow but the backend is functional.