### PR TITLE
Fixed #203 | Disabled Movement of Start and End Tiles

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -1,27 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
   <component name="ChangeListManager">
     <list default="true" id="c6a87c20-86fe-4292-a35b-df0757131668" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/Assets/Art/3D Models/SnowIsland_v1.fbx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/Assets/Art/3D Models/SnowIsland_v1.fbx.meta" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/../../01 Assets/01 Art/SnowIsland_v1.fbx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Dialogue/Localization/LineTable Shared Data.asset" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Dialogue/Localization/LineTable Shared Data.asset" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Dialogue/Localization/LineTable_en.asset" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Dialogue/Localization/LineTable_en.asset" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/AddressableAssetsData/AddressableAssetSettings.asset" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/AddressableAssetsData/AddressableAssetSettings.asset" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
+  <component name="CopilotPersistence">
+    <persistenceIdMap>
+      <entry key="_C:/Users/nikki/untitled-26/00 Unity Proj/Untitled-26" value="3AiKk4WjnV2ik3wAzho9eBg3aqX" />
+    </persistenceIdMap>
+  </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/../.." />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "git-widget-placeholder": "#176 on Rebasing issue/173-import-ice-island-3d-model"
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 0
+}</component>
+  <component name="ProjectId" id="3AiKk4WjnV2ik3wAzho9eBg3aqX" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;git-widget-placeholder&quot;: &quot;issue/203-disable-movement-of-start-and-end-tiles&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Attach to Unity Editor.Attach to Unity Editor">
     <configuration name="Standalone Player" type="RunUnityExe" factoryName="Unity Executable">
       <option name="EXE_PATH" value="$USER_HOME$/Desktop/v0.4.1-prototype.1\Untitled-26.exe" />
@@ -53,7 +67,7 @@
       <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
-    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
+    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost" useMixedMode="false">
       <option name="allowRunningInParallel" value="false" />
       <option name="listenPortForConnections" value="false" />
       <option name="pid" />
@@ -64,7 +78,6 @@
       <option name="selectedOptions">
         <list />
       </option>
-      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to" type="UnityDevicePlayer" factoryName="UnityAttachToDevicePlayer">
@@ -72,8 +85,32 @@
     </configuration>
   </component>
   <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="c6a87c20-86fe-4292-a35b-df0757131668" name="Changes" comment="" />
+      <created>1773070093734</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1773070093734</updated>
+      <workItem from="1773070101842" duration="3951000" />
+    </task>
     <servers />
   </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
   <component name="UnityProjectConfiguration" hasMinimizedUI="true" />
+  <component name="UnityProjectDiscoverer">
+    <option name="hasUnityReference" value="true" />
+    <option name="unityProject" value="true" />
+    <option name="unityProjectFolder" value="true" />
+  </component>
   <component name="UnityUnitTestConfiguration" currentTestLauncher="Both" />
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
+  </component>
 </project>

--- a/00 Unity Proj/Untitled-26/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/00 Unity Proj/Untitled-26/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_DefaultGroup: b69275c9d3c3eba4cbf99121875580ac
   m_currentHash:
     serializedVersion: 2
-    Hash: 507176e14b970b5d7f1e28dd9cca0581
+    Hash: 00000000000000000000000000000000
   m_OptimizeCatalogSize: 0
   m_BuildRemoteCatalog: 0
   m_CatalogRequestsTimeout: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -26,9 +26,6 @@ public class PlayerFixedMovement : MonoBehaviour
     // (Not necessarily within the grid)
     private GameObject startTile;
     private GameObject endTile;
-    
-    public int gridX;
-    public int gridZ;
 
     // The Player's X and Z coordinates on the grid.
     [SerializeField] private int playerGridX;
@@ -167,8 +164,8 @@ public class PlayerFixedMovement : MonoBehaviour
             return;
         }
         
-        gridX = newX;
-        gridZ = newZ;
+        int gridX = newX;
+        int gridZ = newZ;
 
         // TODO: Add tile type checking here to handle special mechanics.
         //       The same should be done with a normal tile.

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
@@ -3,6 +3,9 @@ using UnityEngine.InputSystem;
 
 public class TileSelector : MonoBehaviour
 {
+    // ===== Variables =====
+    private GridManager gridManager;
+
     /// <summary>
     /// Reference to the currently selected tile.
     /// </summary>
@@ -13,17 +16,25 @@ public class TileSelector : MonoBehaviour
     /// </summary>
     private int playerGridX;
     private int playerGridZ;
-    
+
+    // The starting and ending tile's coordinates
+    private int startTileX;
+    private int startTileZ;
+    private int endTileX;
+    private int endTileZ;
+
     // Subscribe to events
     private void OnEnable()
     {
         PlayerFixedMovement.playerMoved += UpdatePlayerCoordinates;
+        InteractablePillar.puzzleTriggered += AssignStartAndEndTiles;
     }
     
     // Unsubscribe from events
     private void OnDisable()
     {
         PlayerFixedMovement.playerMoved -= UpdatePlayerCoordinates;
+        InteractablePillar.puzzleTriggered += AssignStartAndEndTiles;
     }
 
     void Update()
@@ -57,29 +68,75 @@ public class TileSelector : MonoBehaviour
         playerGridX = playerX;
         playerGridZ = playerZ;
     }
+
+    /// <summary>
+    /// Assigns the coordinates of the start and end tiles for the current puzzle.
+    /// This is used to prevent the Player from moving these tiles.
+    /// </summary>
+    /// <param name="puzzleInformation"></param>
+    private void AssignStartAndEndTiles(PuzzleInformation puzzleInfo)
+    {
+        // Assign the GridManager and the Start & End tiles
+        gridManager = puzzleInfo.gridManager.GetComponent<GridManager>();
+        GameObject startTile = puzzleInfo.startTile;
+        GameObject endTile = puzzleInfo.endTile;
+        
+        // Get the grid coordinates of the starting tile
+        startTileX = startTile.GetComponent<SelectableTile>().gridX;
+        startTileZ = startTile.GetComponent<SelectableTile>().gridZ;
+        
+        // Get the grid coordinates of the end tile
+        endTileX = endTile.GetComponent<SelectableTile>().gridX;
+        endTileZ = endTile.GetComponent<SelectableTile>().gridZ;
+    }
     
     /// <summary>
     /// Checks if the Player is currently on the selected tile. If so, it prevents
     /// the system from continuing before even attempting to move the tile.
     /// </summary>
     /// <returns></returns>
-    private bool PlayerOnSelectedCube()
+    private bool PlayerOnSelectedTile()
     {
         if (selectedTile.gridX == playerGridX && selectedTile.gridZ == playerGridZ)
         {
-            Debug.Log("Cannot move tile: Player is on it.");
+            Debug.Log("TileSelector.cs >> Cannot the tile the Player is currently on.");
             
             return true;
         }
         return false;
     }
 
+    /// <summary>
+    /// Checks if the current tile is either the start or end tile.
+    /// </summary>
+    /// <returns></returns>
+    private bool SelectedTileIsStartOrEnd()
+    {
+        // Check for Start tile
+        if (selectedTile.gridX == startTileX && selectedTile.gridZ == startTileZ)
+        {
+            Debug.Log("TileSelector.cs >> Cannot move the Start tile.");
+
+            return true;
+        }
+
+        // Check for End tile
+        if (selectedTile.gridX == endTileX && selectedTile.gridZ == endTileZ)
+        {
+            Debug.Log("TileSelector.cs >> Cannot move the End tile.");
+            return true;
+        }
+
+        return false;
+    }
+
     public void MoveSelectedRight()
     {
-        // Ensure that a tile is selected and that the Player is
-        // not on the selected tile before trying to move it.
+        // Ensure that a tile is selected, and that we're not moving
+        // the start tile, the end tile, or the Player-occupied tile.
         if (selectedTile == null) return;
-        if (PlayerOnSelectedCube()) return;
+        if (PlayerOnSelectedTile()) return;
+        if (SelectedTileIsStartOrEnd()) return;
 
         if (!ResourceManager.Instance.UseMove("Right")) return;
         
@@ -88,10 +145,11 @@ public class TileSelector : MonoBehaviour
 
     public void MoveSelectedLeft()
     {
-        // Ensure that a tile is selected and that the Player is
-        // not on the selected tile before trying to move it.
+        // Ensure that a tile is selected, and that we're not moving
+        // the start tile, the end tile, or the Player-occupied tile.
         if (selectedTile == null) return;
-        if (PlayerOnSelectedCube()) return;
+        if (PlayerOnSelectedTile()) return;
+        if (SelectedTileIsStartOrEnd()) return;
 
         if (!ResourceManager.Instance.UseMove("Left")) return;
         
@@ -100,10 +158,11 @@ public class TileSelector : MonoBehaviour
 
     public void MoveSelectedForward()
     {
-        // Ensure that a tile is selected and that the Player is
-        // not on the selected tile before trying to move it.
+        // Ensure that a tile is selected, and that we're not moving
+        // the start tile, the end tile, or the Player-occupied tile.
         if (selectedTile == null) return;
-        if (PlayerOnSelectedCube()) return;
+        if (PlayerOnSelectedTile()) return;
+        if (SelectedTileIsStartOrEnd()) return;
 
         if (!ResourceManager.Instance.UseMove("Forward")) return;
         
@@ -112,10 +171,11 @@ public class TileSelector : MonoBehaviour
 
     public void MoveSelectedBack()
     {
-        // Ensure that a tile is selected and that the Player is
-        // not on the selected tile before trying to move it.
+        // Ensure that a tile is selected, and that we're not moving
+        // the start tile, the end tile, or the Player-occupied tile.
         if (selectedTile == null) return;
-        if (PlayerOnSelectedCube()) return;
+        if (PlayerOnSelectedTile()) return;
+        if (SelectedTileIsStartOrEnd()) return;
 
         if (!ResourceManager.Instance.UseMove("Back")) return;
         


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/203-disable-movement-of-start-and-end-tiles`](https://github.com/Precipice-Games/untitled-26/tree/issue/203-disable-movement-of-start-and-end-tiles) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #203.

### In-depth Details
- In [#155](https://github.com/Precipice-Games/untitled-26/pull/155), I implemented logic in TileSelector.cs that disabled movement of the tile the Player is currently on.
- I replicated that similar logic here, but with the start and end tiles.
- This was done by creating a method named AssignStartAndEndTiles(), which is subscribed to puzzleTriggered from InteractablePillar.cs (c1bd456).
     - Anytime we interact with a new puzzle, the grid values of the start and end tiles will be updated.
- The values are compared with the currently selected tile to ensure that the start and end locations don't vary.
- If the Player attempts to move them, a message denying it will be printed to the console.


https://github.com/user-attachments/assets/86881278-2193-4767-b506-cb1e03af15ec