### PR TITLE
Fixed #199 | Press 'Esc' to Pause

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControls.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControls.cs
@@ -593,6 +593,17 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                 },
                 {
                     ""name"": """",
+                    ""id"": ""a05b02b8-741c-4036-9111-923cbb57dc65"",
+                    ""path"": ""<Keyboard>/escape"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Keyboard&Mouse"",
+                    ""action"": ""Pause"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
                     ""id"": ""eb40bb66-4559-4dfa-9a2f-820438abb426"",
                     ""path"": ""<Keyboard>/space"",
                     ""interactions"": """",
@@ -1095,7 +1106,7 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                 {
                     ""name"": """",
                     ""id"": ""82627dcc-3b13-4ba9-841d-e4b746d6553e"",
-                    ""path"": ""<Keyboard>/escape"",
+                    ""path"": ""<Keyboard>/l"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": ""Keyboard&Mouse"",
@@ -1245,6 +1256,17 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""action"": ""Pause"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""eb00346c-eabe-43db-b2f8-30f465280613"",
+                    ""path"": ""<Keyboard>/escape"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Keyboard&Mouse"",
+                    ""action"": ""Pause"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         },
@@ -1332,6 +1354,17 @@ public partial class @PlayerControls: IInputActionCollection2, IDisposable
                     ""name"": """",
                     ""id"": ""186f61b7-cb48-49a6-90b3-a31593db74c2"",
                     ""path"": ""<Keyboard>/t"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": "";Keyboard&Mouse"",
+                    ""action"": ""Pause"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""a7b2ed17-c795-4b4c-9f77-76bf53ceb695"",
+                    ""path"": ""<Keyboard>/escape"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": "";Keyboard&Mouse"",

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControls.inputactions
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControls.inputactions
@@ -507,6 +507,17 @@
                 },
                 {
                     "name": "",
+                    "id": "a05b02b8-741c-4036-9111-923cbb57dc65",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "eb40bb66-4559-4dfa-9a2f-820438abb426",
                     "path": "<Keyboard>/space",
                     "interactions": "",
@@ -1009,7 +1020,7 @@
                 {
                     "name": "",
                     "id": "82627dcc-3b13-4ba9-841d-e4b746d6553e",
-                    "path": "<Keyboard>/escape",
+                    "path": "<Keyboard>/l",
                     "interactions": "",
                     "processors": "",
                     "groups": "Keyboard&Mouse",
@@ -1159,6 +1170,17 @@
                     "action": "Pause",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "eb00346c-eabe-43db-b2f8-30f465280613",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },
@@ -1246,6 +1268,17 @@
                     "name": "",
                     "id": "186f61b7-cb48-49a6-90b3-a31593db74c2",
                     "path": "<Keyboard>/t",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a7b2ed17-c795-4b4c-9f77-76bf53ceb695",
+                    "path": "<Keyboard>/escape",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Keyboard&Mouse",


### PR DESCRIPTION
Overview
- Pulling the latest version of [`issue/199-add-esc-to-input-map-for-pausing-game`](https://github.com/Precipice-Games/untitled-26/tree/issue/199-add-esc-to-input-map-for-pausing-game) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR closes #199 


In-Depth Details
- After feedback from the most recent playtesting session, added the ability to pause the game by pressing 'Esc'
- You are also still able to pause the game by pressing 'T'