### PR TITLE
Hotfix | Restored a Patch to onPuzzleTrigger()

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
@@ -306,6 +306,7 @@ MonoBehaviour:
       m_Calls: []
   rb: {fileID: 0}
   _playerInput: {fileID: 6922169669516928053}
+  debugMode: 1
 --- !u!114 &1173698383739407512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -331,8 +332,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf41f4705f0140eb94391cf0bb44adfb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerFixedMovement
-  gridX: 0
-  gridZ: 0
   playerGridX: 0
   playerGridZ: 0
   puzzleCompleted:
@@ -409,6 +408,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerRaycastInteraction
   rayLength: 2.5
+  raycastEnabled: 1
   activeInteractable: {fileID: 0}
   canInteract: 1
   interactionUI: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -1223,25 +1223,9 @@ PrefabInstance:
       value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1604888279}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: onPuzzleTrigger
-      objectReference: {fileID: 0}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameStateManager, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 6739596773503058293, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: rayLength
       value: 5

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
@@ -231,24 +231,13 @@ public class GameStateManager : MonoSingleton<GameStateManager>
     /// </summary>
     public void onPuzzleTrigger()
     {
-        Debug.Log("onPuzzleTrigger() >> The current game state is: " + CurrentGameState);
-        
-        if (CurrentGameState != GameState.Puzzle)
-        {
-            Debug.Log("onPuzzleTrigger() >> Entered the if statement to transition to Puzzle Mode.");
-            TransitionToState(GameState.Puzzle);
-        }
-        else
-        {
-            TransitionToState(prevState);
-        }
+        TransitionToState(GameState.Puzzle);
     }
-
-    // FIXME: This is currently being triggered by the Player reaching
-    // the end tile of a puzzle, however, we should really be using the
-    // onPuzzleTrigger() method above. For whatever reason, the prevState
-    // variable isn't being updated correctly, causing us to not switch
-    // out of Puzzle Mode.
+    
+    /// <summary>
+    /// This switches the Player back to Exploration mode upon the triggering
+    /// of puzzleCompleted, a UnityEvent defined in PlayerFixedMovement.cs.
+    /// </summary>
     public void onPuzzleCompleted()
     {
         TransitionToState(GameState.Exploration);

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
@@ -34,6 +34,8 @@ public class ViewManager : MonoBehaviour
     public Camera menuCamera;
     private Camera _targetCamera;
 
+    [Space]
+    [Title("Puzzle Triggering Event", "Event fired when the Player interacts with an InteractablePillar.")]
     public UnityEvent puzzleSwitchDetected;
     
     [Title("Debug Mode")]

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -4,6 +4,7 @@ using UnityEditor.Build;
 
 using System;
 using System.Numerics;
+using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.InputSystem;
@@ -27,7 +28,7 @@ public class PlayerFixedMovement : MonoBehaviour
     private GameObject startTile;
     private GameObject endTile;
 
-    // The Player's X and Z coordinates on the grid.
+    [Title("Player's Grid Coordinates")]
     [SerializeField] private int playerGridX;
     [SerializeField] private int playerGridZ;
     
@@ -42,12 +43,13 @@ public class PlayerFixedMovement : MonoBehaviour
     Vector3 newPosition;
 
    // Player's Rigidbody
-    Rigidbody rb;
+    private Rigidbody rb;
     
     // Static event to notify subscribers of the Player's movement
     public static event Action<int, int> playerMoved;
     
-    // Event fired when Player reaches the end tile of the puzzle
+    [Space]
+    [Title("Puzzle Completion Event", "Event fired when Player reaches the end tile of the puzzle.")]
     public UnityEvent puzzleCompleted;
 
     private void Start()
@@ -200,7 +202,6 @@ public class PlayerFixedMovement : MonoBehaviour
         {
             Debug.Log($"PlayerFixedMovement.cs >> Player has reached the end tile at [{endTileX}, {endTileZ}].");
             puzzleCompleted.Invoke();
-            // GameStateManager.puzzleSwitchDetected.Invoke();
         }
         
         playerMoved?.Invoke(playerGridX, playerGridZ);


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`hotfix/restore-onpuzzletrigger-patch`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/restore-onpuzzletrigger-patch) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes a bug by ultimately rolling back the changes from [#215](https://github.com/Precipice-Games/untitled-26/pull/215).

### In-depth Details
- Back in [#215](https://github.com/Precipice-Games/untitled-26/pull/215), I thought I'd _finally_ resolved a bug regarding the onPuzzleTrigger() method.
- While everything worked completely fine in the Unity Editor, it appears some data must be lost when actually building and testing the game as an .exe.
- That being said, I rolled back the changes made there, restoring the patched methodology, which centered around having two separate methods:
     - onPuzzleTrigger(): Triggered by the puzzleSwitchDetected event in ViewManager.cs.
     - onPuzzleCompletion(): Triggered by the puzzleCompleted event in PlayerFixedMovement.cs.
- I tested this in _both_ the Editor and a built .exe, so it should work without any problems.
- Now merging this back into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev) to then merge into [`main`](https://github.com/Precipice-Games/untitled-26/tree/main) for a re-patched release.