### PR TITLE
Merging Re-patch of onPuzzleTrigger() Methodology into Main

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
@@ -306,6 +306,7 @@ MonoBehaviour:
       m_Calls: []
   rb: {fileID: 0}
   _playerInput: {fileID: 6922169669516928053}
+  debugMode: 1
 --- !u!114 &1173698383739407512
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -331,8 +332,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf41f4705f0140eb94391cf0bb44adfb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerFixedMovement
-  gridX: 0
-  gridZ: 0
   playerGridX: 0
   playerGridZ: 0
   puzzleCompleted:
@@ -409,6 +408,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PlayerRaycastInteraction
   rayLength: 2.5
+  raycastEnabled: 1
   activeInteractable: {fileID: 0}
   canInteract: 1
   interactionUI: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -1223,25 +1223,9 @@ PrefabInstance:
       value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1604888279}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: onPuzzleTrigger
-      objectReference: {fileID: 0}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: GameStateManager, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 6709136814799094051, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: puzzleCompleted.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 6739596773503058293, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: rayLength
       value: 5

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
@@ -231,24 +231,13 @@ public class GameStateManager : MonoSingleton<GameStateManager>
     /// </summary>
     public void onPuzzleTrigger()
     {
-        Debug.Log("onPuzzleTrigger() >> The current game state is: " + CurrentGameState);
-        
-        if (CurrentGameState != GameState.Puzzle)
-        {
-            Debug.Log("onPuzzleTrigger() >> Entered the if statement to transition to Puzzle Mode.");
-            TransitionToState(GameState.Puzzle);
-        }
-        else
-        {
-            TransitionToState(prevState);
-        }
+        TransitionToState(GameState.Puzzle);
     }
-
-    // FIXME: This is currently being triggered by the Player reaching
-    // the end tile of a puzzle, however, we should really be using the
-    // onPuzzleTrigger() method above. For whatever reason, the prevState
-    // variable isn't being updated correctly, causing us to not switch
-    // out of Puzzle Mode.
+    
+    /// <summary>
+    /// This switches the Player back to Exploration mode upon the triggering
+    /// of puzzleCompleted, a UnityEvent defined in PlayerFixedMovement.cs.
+    /// </summary>
     public void onPuzzleCompleted()
     {
         TransitionToState(GameState.Exploration);

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
@@ -34,6 +34,8 @@ public class ViewManager : MonoBehaviour
     public Camera menuCamera;
     private Camera _targetCamera;
 
+    [Space]
+    [Title("Puzzle Triggering Event", "Event fired when the Player interacts with an InteractablePillar.")]
     public UnityEvent puzzleSwitchDetected;
     
     [Title("Debug Mode")]

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -4,6 +4,7 @@ using UnityEditor.Build;
 
 using System;
 using System.Numerics;
+using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.InputSystem;
@@ -27,7 +28,7 @@ public class PlayerFixedMovement : MonoBehaviour
     private GameObject startTile;
     private GameObject endTile;
 
-    // The Player's X and Z coordinates on the grid.
+    [Title("Player's Grid Coordinates")]
     [SerializeField] private int playerGridX;
     [SerializeField] private int playerGridZ;
     
@@ -42,12 +43,13 @@ public class PlayerFixedMovement : MonoBehaviour
     Vector3 newPosition;
 
    // Player's Rigidbody
-    Rigidbody rb;
+    private Rigidbody rb;
     
     // Static event to notify subscribers of the Player's movement
     public static event Action<int, int> playerMoved;
     
-    // Event fired when Player reaches the end tile of the puzzle
+    [Space]
+    [Title("Puzzle Completion Event", "Event fired when Player reaches the end tile of the puzzle.")]
     public UnityEvent puzzleCompleted;
 
     private void Start()
@@ -200,7 +202,6 @@ public class PlayerFixedMovement : MonoBehaviour
         {
             Debug.Log($"PlayerFixedMovement.cs >> Player has reached the end tile at [{endTileX}, {endTileZ}].");
             puzzleCompleted.Invoke();
-            // GameStateManager.puzzleSwitchDetected.Invoke();
         }
         
         playerMoved?.Invoke(playerGridX, playerGridZ);


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev) into [`main`](https://github.com/Precipice-Games/untitled-26/tree/main).
- This PR introduces the changes merged in [#217](https://github.com/Precipice-Games/untitled-26/pull/217).

### In-depth Details
- In [#216](https://github.com/Precipice-Games/untitled-26/pull/216), I mentioned that I'd figured out the issue with the onPuzzleTrigger() method in GameStateManager.cs.
     - Specifically, we could switch into puzzles, but not out.
- I thought I'd fixed this in [#215](https://github.com/Precipice-Games/untitled-26/pull/215), as everything was running completely fine in the Unity Editor.
- However, when I tried to test it on a built .exe, the changes didn't seem to carry over.
- I'm not entirely sure why this is, but I re-patched the changes in [#217](https://github.com/Precipice-Games/untitled-26/pull/217) and can confirm that it's now working in Unity and the build.
- As a side note, I improved the tooltip and title formatting in the editor as well, just so that these events are a bit clearer (71bc5f6).
- This is for entering a puzzle:

<p>
<img src="https://github.com/user-attachments/assets/9266dc37-8a54-4850-a03f-45247b192a87" alt="ViewManager" width="70%" style="max-width: 100%;">
</p>

- And this is for exiting a puzzle:

<p>
<img src="https://github.com/user-attachments/assets/093fd91e-f700-4d42-b219-2c22365f64ab" alt="PlayerFixedMovement" width="70%" style="max-width: 100%;">
</p>