### PR TITLE
Fixed #221 | Disabled Interaction Prompt While Paused

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -5,8 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="c6a87c20-86fe-4292-a35b-df0757131668" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/Assets/Scripts/UI/InteractionPrompt.cs" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/Assets/Scripts/UI/InteractionPrompt.cs.meta" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/UI/InteractPrompt.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/UI/InteractPrompt.prefab" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/MovementScripts.meta" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerRaycastInteraction.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerRaycastInteraction.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -34,12 +39,7 @@
   }
 }</component>
   <component name="HighlightingSettingsPerFile">
-    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/ILViewer/4e3b370cb1a3412e898e5cbf39ff2af63de00/fa/9916362b/02000007pdb7.il" root0="FORCE_HIGHLIGHTING" />
-    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/ILViewer/5633fb5b8ea043caa8bcc5b423134f4c3de00/20/5f988111/0200001Bpdb27.il" root0="FORCE_HIGHLIGHTING" />
-    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/ILViewer/5633fb5b8ea043caa8bcc5b423134f4c3de00/a6/9597788b/02000007pdb7.il" root0="FORCE_HIGHLIGHTING" />
-    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/18b3b31e3d8341f487466ebb6800bc67212400/1a/0a0d0392/Debug.cs" root0="FORCE_HIGHLIGHTING" />
-    <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/18b3b31e3d8341f487466ebb6800bc67212400/7f/25df0b03/ILogger.cs" root0="FORCE_HIGHLIGHTING" />
-    <setting file="file://$PROJECT_DIR$/Assets/Scripts/DevTools/SelectiveDebugger.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/UI/InteractionPrompt.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/dev.yarnspinner.unity@040b0f4542b5/Runtime/DialogueRunner/DialogueRunner.cs" root0="SKIP_HIGHLIGHTING" />
   </component>
   <component name="ProjectColorInfo">{
@@ -50,23 +50,23 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;issue/213-debug-test-the-gamestatemanager-assignments-of-the-current-state&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "git-widget-placeholder": "issue/221-ensure-interaction-prompt-invisible-if-paused",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected="Attach to Unity Editor.Attach to Unity Editor">
     <configuration name="Standalone Player" type="RunUnityExe" factoryName="Unity Executable">
-      <option name="EXE_PATH" value="$USER_HOME$/Desktop/v0.4.1-prototype.1\Untitled-26.exe" />
+      <option name="EXE_PATH" value="$USER_HOME$/Desktop/v0.4.3-prototype.1\Untitled-26.exe" />
       <option name="PROGRAM_PARAMETERS" value="" />
       <option name="WORKING_DIRECTORY" value="C:\Users\nikki\Desktop\v0.4.1-prototype.1" />
       <option name="PASS_PARENT_ENVS" value="1" />
@@ -95,7 +95,7 @@
       <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
-    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
+    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost" useMixedMode="false">
       <option name="allowRunningInParallel" value="false" />
       <option name="listenPortForConnections" value="false" />
       <option name="pid" />
@@ -106,7 +106,6 @@
       <option name="selectedOptions">
         <list />
       </option>
-      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to" type="UnityDevicePlayer" factoryName="UnityAttachToDevicePlayer">
@@ -123,6 +122,7 @@
       <workItem from="1773070101842" duration="3951000" />
       <workItem from="1773164067385" duration="401000" />
       <workItem from="1773171978578" duration="4507000" />
+      <workItem from="1773259899547" duration="1069000" />
     </task>
     <servers />
   </component>

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/UI/InteractPrompt.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/UI/InteractPrompt.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 5523384014667715397}
   - component: {fileID: 5858514601374460139}
   - component: {fileID: 724371074316278936}
+  - component: {fileID: 5003682050977052313}
   m_Layer: 5
   m_Name: InteractPrompt
   m_TagString: Untagged
@@ -102,6 +103,18 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 119
+--- !u!114 &5003682050977052313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4961419121846845136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f35f5d9f7c8141d29ba323a05427631d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InteractionPrompt
 --- !u!1 &5133917020356748328
 GameObject:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerRaycastInteraction.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerRaycastInteraction.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using static UnityEngine.UI.Image;
@@ -22,6 +23,9 @@ public class PlayerRaycastInteraction : MonoBehaviour
     //    ==== Timer ====
     public float activeTimer = 5.0f;
     public float maxTime = 5.0f;
+    
+    // Static event to notify subscribers of raycast toggling
+    public static event Action<bool> raycastToggled;
 
     /*
      * 
@@ -135,15 +139,22 @@ public class PlayerRaycastInteraction : MonoBehaviour
         GameStateManager.transitionedToNewState -= ToggleRaycast;
     }
 
+    /// <summary>
+    /// This method ensures that the raycast is toggled properly,
+    /// depending on the current state of the game.
+    /// </summary>
+    /// <param name="state"></param>
     public void ToggleRaycast(GameStateManager.GameState state)
     {
         if (state == GameStateManager.GameState.Exploration)
         {
             raycastEnabled = true;
+            raycastToggled?.Invoke(true);
         }
         else
         {
             raycastEnabled = false;
+            raycastToggled?.Invoke(false);
         }
     }
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/UI.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/UI.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 203d2e0b0d5e29549b8f96eac7cbfa86
+guid: 230c7d10d1d0bc246a446be6f1494c22
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/UI/InteractionPrompt.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/UI/InteractionPrompt.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+/// <summary>
+/// This script controls the interaction prompt that appears when the player
+/// is in range of an interactable object. This functionality is designated
+/// in its own script because it's possible that the Player paused while in
+/// range of an interactable object, which does not make the prompt disappear.
+/// </summary>
+public class InteractionPrompt : MonoBehaviour
+{
+    // Subscribe to events
+    private void OnEnable()
+    {
+        PlayerRaycastInteraction.raycastToggled += TogglePrompt;
+    }
+    
+    // Unsubscribe from events
+    private void OnDisable()
+    {
+        PlayerRaycastInteraction.raycastToggled -= TogglePrompt;
+    }
+    
+    /// <summary>
+    /// This method properly toggles the interaction prompt on and
+    /// off, depending on the state of the raycast.
+    /// </summary>
+    /// <param name="isEnabled"></param>
+    private void TogglePrompt(bool isEnabled)
+    {
+        gameObject.SetActive(isEnabled);
+    }
+}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/UI/InteractionPrompt.cs.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/UI/InteractionPrompt.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f35f5d9f7c8141d29ba323a05427631d
+timeCreated: 1773260202


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/221-ensure-interaction-prompt-invisible-if-paused`](https://github.com/Precipice-Games/untitled-26/tree/issue/221-ensure-interaction-prompt-invisible-if-paused) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #221, which is a sub-issue to [#195](https://github.com/Precipice-Games/untitled-26/issues/195).

### In-depth Details
- As mentioned in [#221](https://github.com/Precipice-Games/untitled-26/issues/221), there was an issue with the interaction prompt object in the scene that was causing it to appear when the pause menu was present.
- I created a separate script named InteractionPrompt.cs that handles this.
- It has a single method, TogglePrompt(), that is subscribed to the raycast-toggling methods @cassdaw developed in [#207](https://github.com/Precipice-Games/untitled-26/pull/207).
- It doesn't break or change any of the logic that she deveoped.
- It just receives the updates from the raycast system and toggles the interaction pop-up on/off accordingly.
     - If raycast is disabled (false), then the pop-up should also be disabled.
     - This ensures it is invisible in the paused state.