### PR TITLE
Fixed #198 | Disabled Shadows Cast by Tiles

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -50,20 +50,20 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
-    "git-widget-placeholder": "issue/221-ensure-interaction-prompt-invisible-if-paused",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;issue/221-ensure-interaction-prompt-invisible-if-paused&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Attach to Unity Editor.Attach to Unity Editor">
     <configuration name="Standalone Player" type="RunUnityExe" factoryName="Unity Executable">
       <option name="EXE_PATH" value="$USER_HOME$/Desktop/v0.4.3-prototype.1\Untitled-26.exe" />

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
@@ -52,7 +52,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 115618297942063103}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -131,6 +131,7 @@ MonoBehaviour:
   gridZ: 3
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &5542912942022859257
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -210,7 +211,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 136645902339605885}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -289,6 +290,7 @@ MonoBehaviour:
   gridZ: 3
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &8931899725991205104
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -776,7 +778,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1712450131070757306}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -855,6 +857,7 @@ MonoBehaviour:
   gridZ: 4
   originalColor: {r: 0.8352941, g: 0, b: 1, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &7045734070655998070
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -934,7 +937,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1872530666423440456}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -1013,6 +1016,7 @@ MonoBehaviour:
   gridZ: 1
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &6530514183576964366
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1183,6 +1187,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a71b6132a17b2644b90a1861ebd8c274, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CubeSelector
+  debugMode: 1
 --- !u!114 &6021735229776701839
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1211,6 +1216,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dc1cd66239eb1b34ba660e953023f763, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ClickRayTest
+  debugMode: 1
 --- !u!1 &2065247099526973384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1263,7 +1269,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2065247099526973384}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -1342,6 +1348,7 @@ MonoBehaviour:
   gridZ: 1
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &4406865920393537666
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1558,7 +1565,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2595629101245525352}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -1637,6 +1644,7 @@ MonoBehaviour:
   gridZ: 0
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &453642476825720023
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -1987,7 +1995,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3427067941324799217}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -2066,6 +2074,7 @@ MonoBehaviour:
   gridZ: 0
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &5231381797051820232
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2282,7 +2291,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3796191418792194300}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -2361,6 +2370,7 @@ MonoBehaviour:
   gridZ: 4
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &309107811372590528
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -2440,7 +2450,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3816189780632181019}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -2519,6 +2529,7 @@ MonoBehaviour:
   gridZ: 2
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &3261880673261627557
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -3098,7 +3109,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5059960743704218579}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -3177,6 +3188,7 @@ MonoBehaviour:
   gridZ: 2
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &8734686047623891108
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -3256,7 +3268,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5169605109640841623}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -3335,6 +3347,7 @@ MonoBehaviour:
   gridZ: 4
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &3685197665221182148
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -3900,7 +3913,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6337408609227900163}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -3979,6 +3992,7 @@ MonoBehaviour:
   gridZ: 1
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &7523907909368201943
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -4058,7 +4072,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6609728866790066902}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -4137,6 +4151,7 @@ MonoBehaviour:
   gridZ: 1
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &5886979120025315524
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -4293,7 +4308,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6919531168105839388}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -4372,6 +4387,7 @@ MonoBehaviour:
   gridZ: 0
   originalColor: {r: 0.13494706, g: 1, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &1780069663387497229
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -4553,7 +4569,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7470132292000716953}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -4632,6 +4648,7 @@ MonoBehaviour:
   gridZ: 2
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &8379635494583041761
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -4713,6 +4730,7 @@ MonoBehaviour:
   moveRightUses: 2
   moveForwardUses: 2
   moveBackUses: 2
+  debugMode: 1
 --- !u!1 &7860005051175498032
 GameObject:
   m_ObjectHideFlags: 0
@@ -4902,7 +4920,7 @@ MeshRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8066876773405094797}
   m_Enabled: 1
-  m_CastShadows: 1
+  m_CastShadows: 0
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
   m_StaticShadowCaster: 0
@@ -4981,6 +4999,7 @@ MonoBehaviour:
   gridZ: 2
   originalColor: {r: 0, g: 0, b: 0, a: 0}
   highlightColor: {r: 0.015686274, g: 0.8790853, b: 1, a: 1}
+  debugMode: 1
 --- !u!54 &2308668415581002923
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/198-remove-shadows-from-puzzle-tiles`](https://github.com/Precipice-Games/untitled-26/tree/issue/198-remove-shadows-from-puzzle-tiles) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #198.

### In-depth Details
- A piece of feedback we received from several playtesters was possibly disabling the shadows that were cast by puzzle tiles
     - The shadows are very sharp and a bit distracting.
     - This is in part because we haven't really set up actual lighting environments, we're just using the default light.
- I disabled "Cast Shadows" on all of the tiles on the Puzzle1.prefab object (4f380c9).
- We could always reimplement them in a future iteration if needed.