### PR TITLE
Fixed #238 | Player.cs Configures Orientation for Game State

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
   <component name="ChangeListManager">
-    <list default="true" id="5e5ce399-7c0f-4455-b410-4ddcc8af76a2" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/IslandManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/IslandManager.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs" afterDir="false" />
-    </list>
+    <list default="true" id="5e5ce399-7c0f-4455-b410-4ddcc8af76a2" name="Changes" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -27,7 +26,8 @@
   </component>
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
-    "git-widget-placeholder": "issue/167-connect-puzzle-completion-to-yarnspinner-memory"
+    "git-widget-placeholder": "issue/238-make-sky-sprite-visible-in-puzzle-mode",
+    "node.js.selected.package.tslint": "(autodetect)"
   }
 }]]></component>
   <component name="TaskManager">

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/Player.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/Player.cs
@@ -52,6 +52,7 @@ public class Player : MonoSingleton<Player>
         InputManager.inputMapSwitched += SwitchActionMap;
         InputManager.cursorChanged += SwitchCursorFunctionality;
         PhysicsManager.kinematicsUpdated += SwitchKinematics;
+        GameStateManager.transitionedToNewState += ConfigureOrientation;
 
 
         _playerControls.UI.Enable();
@@ -66,6 +67,7 @@ public class Player : MonoSingleton<Player>
         InputManager.inputMapSwitched -= SwitchActionMap;
         InputManager.cursorChanged -= SwitchCursorFunctionality;
         PhysicsManager.kinematicsUpdated -= SwitchKinematics;
+        GameStateManager.transitionedToNewState -= ConfigureOrientation;
         
         _playerControls.UI.Disable();
         _playerControls.Player.Disable();
@@ -123,5 +125,25 @@ public class Player : MonoSingleton<Player>
     {
         rb.isKinematic = isKinematic;
         Debug.Log("Player.cs >> Kinematics were set to " + isKinematic);
+    }
+    
+    /// <summary>
+    /// Used to configure the Player's orientation based on the game state.
+    /// For instance, the orientation should be different in Puzzle mode to
+    /// ensure we can see Skye's sprite properly.
+    /// </summary>
+    /// <param name="newState"></param>
+    private void ConfigureOrientation(GameStateManager.GameState newState)
+    {
+        // If we're in Puzzle Mode, we want to orient the Player so
+        // her 2D sprite is more visible to the camera.
+        if (newState != GameStateManager.GameState.Puzzle)
+        {
+            transform.rotation = Quaternion.Euler(0, transform.rotation.y, transform.rotation.z);
+        }
+        else
+        {
+            transform.rotation = Quaternion.Euler(90, transform.rotation.y, transform.rotation.z);
+        }
     }
 }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/238-make-sky-sprite-visible-in-puzzle-mode`](https://github.com/Precipice-Games/untitled-26/tree/issue/238-make-sky-sprite-visible-in-puzzle-mode) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #238.

### In-depth Details
- Player.cs was updated with a new method named ConfigureOrientation().
- The method is subscribed to the transitionedToNewState event from GameStateManager.cs.
- It adjusts the rotation of the Player based on the current game state.
- If we enter Puzzle mode, we rotate the Player 90° on the x-axis.
- In any other state, we should return to 0° for normal navigation.
- Her 2D design is now visible even from the camera overhead view.