### PR TITLE
Hotfix | Improved Debugging Options for Puzzle Mode

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -6,9 +6,10 @@
   <component name="ChangeListManager">
     <list default="true" id="5e5ce399-7c0f-4455-b410-4ddcc8af76a2" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/AddressableAssetsData/AddressableAssetSettings.asset" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/AddressableAssetsData/AddressableAssetSettings.asset" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/ProjectSettings/TagManager.asset" beforeDir="false" afterPath="$PROJECT_DIR$/ProjectSettings/TagManager.asset" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/BoxCastGrounded.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/BoxCastGrounded.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerRaycastInteraction.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerRaycastInteraction.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/GridManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/GridManager.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -23,18 +24,18 @@
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/../.." />
   </component>
-  <component name="GitHubPullRequestSearchHistory"><![CDATA[{
-  "lastFilter": {
-    "state": "OPEN",
-    "assignee": "Nicole-Scalera"
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;Nicole-Scalera&quot;
   }
-}]]></component>
-  <component name="GithubPullRequestsUISettings"><![CDATA[{
-  "selectedUrlAndAccountId": {
-    "url": "https://github.com/Precipice-Games/untitled-26.git",
-    "accountId": "ec7d3be2-c42a-472e-a6d7-9c09fcb35385"
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;https://github.com/Precipice-Games/untitled-26.git&quot;,
+    &quot;accountId&quot;: &quot;ec7d3be2-c42a-472e-a6d7-9c09fcb35385&quot;
   }
-}]]></component>
+}</component>
   <component name="HighlightingSettingsPerFile">
     <setting file="file://$APPLICATION_CONFIG_DIR$/resharper-host/DecompilerCache/decompiler/18b3b31e3d8341f487466ebb6800bc67212400/e6/03aa9027/Material.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/DynamicTileTexturing.cs" root0="FORCE_HIGHLIGHTING" />
@@ -60,7 +61,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
-    "git-widget-placeholder": "#243 on issue/240-disable-infinite-jump",
+    "git-widget-placeholder": "hotfix/out-of-bounds-puzzle-error",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
@@ -90,7 +91,7 @@
       <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
-    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
+    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost" useMixedMode="false">
       <option name="allowRunningInParallel" value="false" />
       <option name="listenPortForConnections" value="false" />
       <option name="pid" />
@@ -101,7 +102,6 @@
       <option name="selectedOptions">
         <list />
       </option>
-      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to" type="UnityDevicePlayer" factoryName="UnityAttachToDevicePlayer">

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/BoxCastGrounded.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/BoxCastGrounded.cs
@@ -14,7 +14,6 @@ public class BoxCastGrounded : MonoBehaviour
     [Space]
     [Title("Grounded Checker", "General variables used to handle ground checking.")]
     public bool groundChecking = true;
-    public bool canInteract = true;
     private Ray groundInteractionRay;
     private RaycastHit groundRaycastHit;
     bool hittingGround;
@@ -30,6 +29,11 @@ public class BoxCastGrounded : MonoBehaviour
     [PropertyTooltip("Be sure to add a buffer for the ray length to ensure consistency in ground detection.")]
     public float rayLengthBuffer;
     private float groundRayLength; // Actual ray length
+    
+    [Space]
+    [Title("Debugging Options", "Settings for quick debugging options.")]
+    [PropertyTooltip("Print out what ground the Player is standing on. False by default.")]
+    public bool printGroundedStatus = false;
     
     // Static event to notify subscribers of game state changes
     public static event Action<bool> groundCheck;
@@ -67,7 +71,6 @@ public class BoxCastGrounded : MonoBehaviour
         }
         else
         {
-            canInteract = true;
             activeTimer = 0.0f;
         }
 
@@ -85,7 +88,7 @@ public class BoxCastGrounded : MonoBehaviour
             // Turn the ray green
             Debug.DrawRay(origin, direction * groundRayLength, Color.green);
             currentPlatform = groundRaycastHit.collider.gameObject;
-            Debug.Log("Grounded on: " + currentPlatform.name);
+            if (printGroundedStatus) Debug.Log("BoxCastGrounded.cs >> Grounded on: " + currentPlatform.name);
         }
         else
         {

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -100,7 +100,7 @@ public class PlayerFixedMovement : MonoBehaviour
         startTileX = startTile.GetComponent<SelectableTile>().gridX;
         startTileZ = startTile.GetComponent<SelectableTile>().gridZ;
 
-        Debug.Log("Starting X,Z: " + startTileX + "," + startTileZ);
+        Debug.Log($"PlayerFixedMovement.cs >> Starting X,Z: ({startTileX},{startTileZ})");
         
         // Get the grid coordinates of the end tile
         endTileX = endTile.GetComponent<SelectableTile>().gridX;
@@ -185,7 +185,7 @@ public class PlayerFixedMovement : MonoBehaviour
         destinationX += deltaX;
         destinationZ += deltaZ;
 
-        Debug.Log("deltaX,deltaZ" + deltaX + ", " + deltaZ);
+        Debug.Log($"PlayerFixedMovement.cs >> deltaX,deltaZ: ({deltaX},{deltaZ})");
 
         Debug.Log($"PlayerFixedMovement.cs >> Attempting to move the Player to: {destinationX + playerGridX},{destinationX + playerGridX}");
 
@@ -202,10 +202,8 @@ public class PlayerFixedMovement : MonoBehaviour
             return;
         }
 
-        Debug.Log("destinationX: " + destinationX);
-        Debug.Log("destinationZ: " + destinationZ);
-
-        Debug.Log("Dest + pt" + (destinationX + playerGridX) + "," + (destinationZ + playerGridZ));
+        Debug.Log($"PlayerFixedMovement.cs >> Destination: ({destinationX},{destinationZ})");
+        Debug.Log($"PlayerFixedMovement.cs >> Destination + CurrentPosition: ({destinationX + playerGridX},{destinationZ + playerGridZ})");
 
         if (gridManager.IsIceTileType(destinationX + playerGridX, destinationZ + playerGridZ))
         {
@@ -236,6 +234,8 @@ public class PlayerFixedMovement : MonoBehaviour
 
         }
 
+        // TODO: Remove gridX and gridZ? My IDE said they are
+        //       assigned but never used. Lmk. -- Nikki
         int gridX = newX;
         int gridZ = newZ;
 
@@ -243,8 +243,8 @@ public class PlayerFixedMovement : MonoBehaviour
         //       The same should be done with a normal tile.
         // HandleTileType();
 
-        Debug.Log("dest + playerGrid: " + (destinationX + playerGridX) + "," + (destinationZ + playerGridZ));
-        Debug.Log("landings: " + landingX + "," + landingZ);
+        Debug.Log($"PlayerFixedMovement.cs >> Destination + PlayerGrid: ({destinationX + playerGridX},{destinationZ + playerGridZ})");
+        Debug.Log($"PlayerFixedMovement.cs >> Landings: ({landingX},{landingZ})");
 
         // For right now, we will just snap the player to the new tile.
         SnapPlayerToTile(landingX, landingZ);
@@ -252,12 +252,10 @@ public class PlayerFixedMovement : MonoBehaviour
 
     public void SnapPlayerToTile(int coordX, int cordZ)
     {
-
-        Debug.Log(coordX + ", " + cordZ);
         // Grab the X and Z coordinates in Vector3 from the GridManager
         newCoords = gridManager.GridToWorld(coordX, cordZ);
         newPosition = new Vector3(newCoords.x, transform.localPosition.y, newCoords.z);
-        Debug.Log("New Position:" + newPosition);
+        Debug.Log($"PlayerFixedMovement.cs >> New Position: {newPosition}");
         transform.localPosition = newPosition;
 
         playerGridX = coordX;
@@ -276,7 +274,7 @@ public class PlayerFixedMovement : MonoBehaviour
         // Check if the Player's coordinates match the end tile's coordinates
         if (endTileX == playerGridX && endTileZ == playerGridZ)
         {
-            Debug.Log($"PlayerFixedMovement.cs >> Player has reached the end tile at [{endTileX}, {endTileZ}].");
+            Debug.Log($"PlayerFixedMovement.cs >> Player has reached the end tile at ({endTileX}, {endTileZ}).");
 
             transform.parent = null;
             transform.position = new Vector3(3.59f, 0.83f, 21.43f);

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerRaycastInteraction.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerRaycastInteraction.cs
@@ -1,11 +1,16 @@
 using System;
+using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using static UnityEngine.UI.Image;
 
+// This script is responsible for handling the player's interaction-based
+// raycast in the environment. There is another raycast created for the Player
+// in BoxCastGrounded.cs, but that is for ground checks, NOT for interactions
+// in the environment.
+
 public class PlayerRaycastInteraction : MonoBehaviour
 {
-
     //     ==== Player Raycast ====
     Ray interactionRay; //ray to cast
     RaycastHit raycastHit; //information about what is being hit
@@ -23,6 +28,11 @@ public class PlayerRaycastInteraction : MonoBehaviour
     //    ==== Timer ====
     public float activeTimer = 5.0f;
     public float maxTime = 5.0f;
+    
+    [Space]
+    [Title("Debugging Options", "Settings for quick debugging options.")]
+    [PropertyTooltip("Print out what object the Player's raycast is hitting. False by default.")]
+    public bool printRaycastHit = false;
     
     // Static event to notify subscribers of raycast toggling
     public static event Action<bool> raycastToggled;
@@ -50,85 +60,62 @@ public class PlayerRaycastInteraction : MonoBehaviour
 
         if (activeTimer < maxTime)
         {
-            
             activeTimer +=  Time.deltaTime;
-
         }
         else
         {
-
             canInteract = true;
             activeTimer = 0.0f;
-
         }
-
-
+        
         interactionRay.origin = transform.position;
         interactionRay.direction = transform.forward;
 
         Vector3 origin = interactionRay.origin;
         Vector3 direction = interactionRay.direction;
 
+        // Bool to store if the ray is hitting anything
         isHitting = Physics.Raycast(interactionRay, out raycastHit, rayLength);
 
         if (isHitting)
         {
-
             Debug.DrawRay(origin, direction * rayLength, Color.green);
-            Debug.Log(raycastHit.collider.gameObject.name);
+            if (printRaycastHit) Debug.Log($"PlayerRaycastInteraction.cs >> Raycast Hit: {raycastHit.collider.gameObject.name}");
 
             if (raycastHit.collider.GetComponent<IInteractable>() != null)
             {
-
                 activeInteractable = raycastHit.collider.gameObject;
                 interactionUI.SetActive(true);
-
             }
-
         }
         else
         {
-
             Debug.DrawRay(origin, direction * rayLength, Color.red);
             activeInteractable = null;
             interactionUI.SetActive(false);
-
         }
 
     }
-
-    /*
-     * 
-     * If the interact key is pressed the interact function triggers
-     * the Interaction() function of the interactable object
-     * 
-     */
-
+    
+    /// <summary>
+    /// If the interact key is pressed the interact function triggers
+    /// the Interaction() function of the interactable object
+    /// </summary>
     public void Interact()
     {
-
         if (activeInteractable != null && canInteract)
         {
-
             activeInteractable.GetComponent<IInteractable>().Interaction();
             canInteract = false;
             activeInteractable = null;
             interactionUI.SetActive(false);
-
         }
-
     }
-
-
-
-
-    /*
-     * 
-     * Toggles the raycast on and off. Used for dialogue and puzzle states
-     * to prevent the player from interacting with objects while in those states
-     * 
-     */
-
+    
+    /// <summary>
+    /// Toggles the raycast on and off. Used for dialogue and puzzle states
+    /// to prevent the player from interacting with objects while in those states
+    /// </summary>
     private void OnEnable()
     {
         GameStateManager.transitionedToNewState += ToggleRaycast;

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/GridManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/GridManager.cs
@@ -48,15 +48,14 @@ public class GridManager : MonoBehaviour
     /// <returns></returns>
     public bool IsIceTileType(int x, int z)
     {
-
         if (!IsCellEmpty(x,z) && grid[x,z].tileType == SelectableTile.TileType.Ice)
         {
-            Debug.Log("true");
+            // Debug.Log("true");
             return true;
         }
         else
         {
-            Debug.Log("false");
+            // Debug.Log("false");
             return false;
         }
 


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`hotfix/out-of-bounds-puzzle-error`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/out-of-bounds-puzzle-error) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR introduces some debugging improvements in relation to an error I found, which an issue will be created for soon.

### In-depth Details
- Something I brought up to @dbrogen the other day was this weird out-of-bounds error during puzzle mode.

<p>
<img src="https://github.com/user-attachments/assets/431872cb-915e-4437-b3e1-3c84cd25b773" alt="IndexOutOfRange" width="100%" style="max-width: 100%;">
</p>

- There's a lot that goes into the functionality of puzzles, so I decided to improve upon the debugging options.
- For one, I did my best to add the class name prefix to each debug statement (that way we know where something is coming from).
- Secondly, I added two public bools to the raycast classes.
     - PlayerRaycastInteraction.cs: used for standard 'E' interactions in the game ([#14](https://github.com/Precipice-Games/untitled-26/pull/14)).
     - BoxCastGrounded.cs: used for ground detection in the jumping mechanic ([#243](https://github.com/Precipice-Games/untitled-26/pull/243)).
- Because the Player is almost always interacting with something, the raycast calls are being fired constantly.
- I serialized these two bools for easy access in the Inspector.

<p>
<img src="https://github.com/user-attachments/assets/58588bc3-61cc-4552-b0ec-94db5b4b2b20" alt="PrintGroundedStatus" width="60%" style="max-width: 100%;">
</p>

- Toggle them on/off if you want to actually print what the raycast is hitting at any given moment.
- In addition to improving the in-editor experience, this change is to help us debug that out-of-bounds error in puzzle mode.
- I will be creating an issue for this soon so we can properly track it.