### PR TITLE
Fixed #261 | Ice Tile Recursion Logic

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -40,7 +40,13 @@ public class PlayerFixedMovement : MonoBehaviour
     private int endTileZ;
 
     //Keeps track of the potential tile for the player to move to
+    /// <summary>
+    /// The X coordinate of the tile the Player is attempting to move to. This is used to check if the move is valid.
+    /// </summary>
     private int destinationX = 0;
+    /// <summary>
+    /// The Y coordinate of the tile the Player is attempting to move to. This is used to check if the move is valid.
+    /// </summary>
     private int destinationZ = 0;
 
     private int deltaX;
@@ -185,6 +191,7 @@ public class PlayerFixedMovement : MonoBehaviour
     /// <param name="zDir"></param>
     private void MoveDirection(int xDir, int zDir)
     {
+        // reset values of destination coords
         destinationX = 0;
         destinationZ = 0;
         TryToMovePlayer(xDir, zDir);
@@ -213,8 +220,8 @@ public class PlayerFixedMovement : MonoBehaviour
         
         // Calculate the attempted destination based on a move.
         // This is used just for the first tile.
-        int attemptedDestX = playerGridX + deltaX;
-        int attemptedDestZ = playerGridZ + deltaZ;
+        int attemptedDestX = playerGridX + destinationX;
+        int attemptedDestZ = playerGridZ + destinationZ;
         Debug.Log($"PlayerFixedMovement.cs >> Attempted Destination Coordinates: ({attemptedDestX},{attemptedDestZ})");
 
         // destinationX += deltaX;
@@ -329,8 +336,8 @@ public class PlayerFixedMovement : MonoBehaviour
         // without affecting the original destination coordinates. This is
         // necessary to ensure that the Player continues to slide in the
         // correct direction until they reach a non-ice tile or an obstacle.
-        int newDeltaX = destinationX;
-        int newDeltaZ = destinationZ;
+        int newDeltaX = deltaX;
+        int newDeltaZ = deltaZ;
 
         Debug.Log($"PlayerFixedMovement.cs >> newDeltaX/Z Coordinates: ({newDeltaX},{newDeltaZ})");
 

--- a/00 Unity Proj/Untitled-26/Untitled-26.slnx
+++ b/00 Unity Proj/Untitled-26/Untitled-26.slnx
@@ -1,7 +1,0 @@
-﻿<Solution>
-  <Project Path="Sirenix.OdinInspector.Modules.UnityLocalization.Editor.csproj" />
-  <Project Path="Assembly-CSharp.csproj" />
-  <Project Path="Sirenix.OdinInspector.Modules.Unity.Addressables.csproj" />
-  <Project Path="Sirenix.OdinInspector.Modules.UnityMathematics.csproj" />
-  <Project Path="Sirenix.OdinInspector.Modules.UnityLocalization.csproj" />
-</Solution>


### PR DESCRIPTION
Overview
- Pulling the latest version of [`issue/261-fix-ice-tile-recursion-logic`](https://github.com/Precipice-Games/untitled-26.git) into [`dev`](https://github.com/Precipice-Games/untitled-26.git)
- This PR fixes #261 

In-Depth Details
- Changed which variables were used to recursively check tiles next to ice tiles, detailed in #
- Added documentation to variables in FixedPlayerMovement.cs to clarify their use
- deltaX and deltaZ variables are used to remember which direction the player is attempting to move in
- destinationX and destinationZ variables are used to increment how many tiles the player will move in each direction. This is incremented by 1 in the direction of movement for every ice tile in that direction until either: there is a normal tile the player can move to; there is an empty cell; the player would move out of bounds.

This change should solve any ice tile issues (based on my own playtesting), but reviewers please playtest any combination of moving across ice tiles that you can think of.