### PR TITLE
Fixed #264 | Resolved Invalid Singleton Instances Plaguing Puzzle Mode

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
@@ -1413,6 +1413,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a71b6132a17b2644b90a1861ebd8c274, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CubeSelector
+  resourceManager: {fileID: 7213066574574228598}
   debugMode: 1
 --- !u!114 &6021735229776701839
 MonoBehaviour:

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle2.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle2.prefab
@@ -1862,6 +1862,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a71b6132a17b2644b90a1861ebd8c274, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::CubeSelector
+  resourceManager: {fileID: 8431254774441030547}
   debugMode: 0
 --- !u!114 &950110973506805743
 MonoBehaviour:

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -20549,7 +20549,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5840726587507800180, guid: 8983198ca1734284785ea41f83d1e4bf, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.1367
+      value: 0.684
       objectReference: {fileID: 0}
     - target: {fileID: 5840726587507800180, guid: 8983198ca1734284785ea41f83d1e4bf, type: 3}
       propertyPath: m_LocalPosition.z

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
@@ -12,8 +12,6 @@ using TMPro;
 
 public class ResourceManager : MonoBehaviour
 {
-    public static ResourceManager Instance;
-    
     public int startingMana = 5;
     private int currentMana;
 
@@ -42,18 +40,14 @@ public class ResourceManager : MonoBehaviour
     public bool printCardDeductions = true;
     [PropertyTooltip("Print out when a specific movement card has no uses left. True by default.")]
     public bool printCardDrainage = true;
-
-
-    void Awake()
-    {
-        Instance = this;
-    }
-
+    
+    // Subscribe to events
     private void OnEnable()
     {
         ResetPuzzle.resetPuzzle += ResetResources;
     }
 
+    // Unsubscribe from events
     private void OnDisable()
     {
         ResetPuzzle.resetPuzzle -= ResetResources;

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
@@ -6,6 +6,8 @@ public class TileSelector : MonoBehaviour
 {
     // ===== Variables =====
     private GridManager gridManager;
+    [PropertyTooltip("Please assign the ResourceManager for this specific puzzle prefab.")]
+    public ResourceManager resourceManager;
 
     /// <summary>
     /// Reference to the currently selected tile.
@@ -144,7 +146,7 @@ public class TileSelector : MonoBehaviour
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
 
-        if (!ResourceManager.Instance.UseMove("Right")) return;
+        if (!resourceManager.UseMove("Right")) return;
         
         selectedTile.TryMove(1, 0); // moves right
     }
@@ -157,7 +159,7 @@ public class TileSelector : MonoBehaviour
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
 
-        if (!ResourceManager.Instance.UseMove("Left")) return;
+        if (!resourceManager.UseMove("Left")) return;
         
         selectedTile.TryMove(-1, 0); // moves left
     }
@@ -170,7 +172,7 @@ public class TileSelector : MonoBehaviour
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
 
-        if (!ResourceManager.Instance.UseMove("Forward")) return;
+        if (!resourceManager.UseMove("Forward")) return;
         
         selectedTile.TryMove(0, 1); // moves forward
     }
@@ -183,7 +185,7 @@ public class TileSelector : MonoBehaviour
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
 
-        if (!ResourceManager.Instance.UseMove("Back")) return;
+        if (!resourceManager.UseMove("Back")) return;
         
         selectedTile.TryMove(0, -1); // moves back
     }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/264-resolve-invalid-singleton-instances`](https://github.com/Precipice-Games/untitled-26/tree/issue/264-resolve-invalid-singleton-instances) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #264.

### In-depth Details
- Guys... we're so back.
- It turns out the major game-breaking issues we were having with the puzzle system recently (after Puzzle2.prefab was added) were due to the singleton instances from the GridManager and the ResourceManager.
- Because of the way the informational system was designed, each prefab has its own GridManager, ResourceManager, TileSelector, UI, Camera, and so on.
- I think Unity was getting confused by these and it was creating all different issues.
- Both puzzles can now be present in a scene without any issues.
- **IMPORTANT:** Please ensure EVERY SelectableTile within a given puzzle has a reference to the GridManager of its puzzle prefab.
- This can be done easily by selecting all of them at once and dragging the GridManager into the reference slot.

<p>
<img src="https://github.com/user-attachments/assets/c3a5fc2d-40b6-49d4-bd63-460914889717" alt="GridManagerReferences" width="100%" style="max-width: 100%;">
</p>