### PR TITLE
Fixed #290 | Converted Left Click Input in TileSelector.cs to Callbacks

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
@@ -715,7 +715,19 @@ MonoBehaviour:
     m_ActionId: 975b6506-e84c-4991-bf08-03e49d35f4cc
     m_ActionName: 'Puzzle/Point[/Mouse/position,/Pen/position,/Touchscreen/touch0/position,/Touchscreen/touch1/position,/Touchscreen/touch2/position,/Touchscreen/touch3/position,/Touchscreen/touch4/position,/Touchscreen/touch5/position,/Touchscreen/touch6/position,/Touchscreen/touch7/position,/Touchscreen/touch8/position,/Touchscreen/touch9/position]'
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: LeftClickDetected
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: c56fc27a-1aa3-46db-b639-ba707d844a60
     m_ActionName: 'Puzzle/Click[/Mouse/leftButton,/Pen/tip,/Touchscreen/touch0/press,/Touchscreen/touch1/press,/Touchscreen/touch2/press,/Touchscreen/touch3/press,/Touchscreen/touch4/press,/Touchscreen/touch5/press,/Touchscreen/touch6/press,/Touchscreen/touch7/press,/Touchscreen/touch8/press,/Touchscreen/touch9/press]'
   - m_PersistentCalls:

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -1350,6 +1350,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1045250816}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[33].m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1604888280}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[41].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1045250825}
@@ -16987,6 +16991,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a924c33e78973c2418c9b442bde4844d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GameStateManager
+--- !u!114 &1604888280 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2708005216323003206, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+  m_PrefabInstance: {fileID: 1604888278}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65197e0c65b7b8343ae036d2df089ea7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InputManager
 --- !u!1001 &1608569502
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/InputManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/InputManager.cs
@@ -15,6 +15,7 @@ public class InputManager : MonoBehaviour
     // to the current input map as needed.
     public static event Action<string> inputMapSwitched;
     public static event Action<CursorLockMode, bool> cursorChanged;
+    public static event Action leftClickEvent;
 
     [Space]
     [Title("Debugging Options", "Settings for quick debugging options.")]
@@ -126,6 +127,22 @@ public class InputManager : MonoBehaviour
             }
             
             cursorChanged?.Invoke(lockMode, visible);
+        }
+    }
+    
+    /// <summary>
+    /// This is subscribed to the left click input action in the Player action map.
+    /// It is used to invoke the left click event, which TileSelector.cs is
+    /// subscribed to. This is important because there is one TileSelector.cs per
+    /// puzzle, not one per scene, so we can't handle the callback explicitly.
+    /// </summary>
+    /// <param name="context"></param>
+    public void LeftClickDetected(InputAction.CallbackContext context)
+    {
+        if (context.performed)
+        {
+            // Invoke the left click event for any subscribers
+            leftClickEvent?.Invoke();
         }
     }
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
@@ -36,31 +36,35 @@ public class TileSelector : MonoBehaviour
     {
         PlayerFixedMovement.playerMoved += UpdatePlayerCoordinates;
         RuneCircle.puzzleTriggered += AssignStartAndEndTiles;
+        InputManager.leftClickEvent += ClickDetected;
     }
     
     // Unsubscribe from events
     private void OnDisable()
     {
         PlayerFixedMovement.playerMoved -= UpdatePlayerCoordinates;
-        RuneCircle.puzzleTriggered -= AssignStartAndEndTiles; // FIXED
+        RuneCircle.puzzleTriggered -= AssignStartAndEndTiles;
+        InputManager.leftClickEvent -= ClickDetected;
     }
 
-    void Update()
+    /// <summary>
+    /// This method is subscribed to the leftClickEvent invoked by InputManager.cs.
+    /// This is because there is one TileSelector.cs per puzzle rather than one for
+    /// the entire scene, so it cannot be subscribed explicitly.
+    /// </summary>
+    public void ClickDetected()
     {
-        if (Mouse.current.leftButton.wasPressedThisFrame)
+        Ray ray = Camera.main.ScreenPointToRay(Mouse.current.position.ReadValue());
+        if (Physics.Raycast(ray, out RaycastHit hit))
         {
-            Ray ray = Camera.main.ScreenPointToRay(Mouse.current.position.ReadValue());
-            if (Physics.Raycast(ray, out RaycastHit hit))
+            SelectableTile tile = hit.collider.GetComponent<SelectableTile>();
+            if (tile != null)
             {
-                SelectableTile tile = hit.collider.GetComponent<SelectableTile>();
-                if (tile != null)
-                {
-                    if (selectedTile != null)
-                        selectedTile.Deselect();
+                if (selectedTile != null)
+                    selectedTile.Deselect();
 
-                    selectedTile = tile;
-                    selectedTile.Select();
-                }
+                selectedTile = tile;
+                selectedTile.Select();
             }
         }
     }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/290-configure-tileselectorcs-for-inputactionscallbackcontext-events`](https://github.com/Precipice-Games/untitled-26/tree/issue/290-configure-tileselectorcs-for-inputactionscallbackcontext-events) into [`issue/241-add-puzzle-feedback-for-impossible-actions`](https://github.com/Precipice-Games/untitled-26/tree/issue/241-add-puzzle-feedback-for-impossible-actions).
- This PR fixes #290.

### In-depth Details
- I met with @mannykun earlier and we got a chance to make a few enhancements to the puzzle system.
     - e.g., deleting old scripts ([#289](https://github.com/Precipice-Games/untitled-26/pull/289)).
- Just now, I converted the Update() method in TileSelector.cs into a more efficient event chain that is connected to the InputManager.cs.
- The InputManager.cs has a new method named LeftClickDetected, which takes in the `InputActions.CallbackContext` (subscribed via the Inspector).

<p>
<img src="https://github.com/user-attachments/assets/47ad3b21-6b12-411a-8803-e004c901d13f" alt="LeftClickDetected" width="80%" style="max-width: 100%;">
</p>

- When a left click is received, it fires off the new leftClickEvent event.
- This event is picked up by the current TileSelector.cs file.

<p>
<img src="https://github.com/user-attachments/assets/735147d7-3feb-4082-ba0c-d3ab601e7b80" alt="EventSubscription" width="80%" style="max-width: 100%;">
</p>

- It then runs its ClickDetected() method.
     - All logic is exactly the same as @mannykun initially designed.
- This allows for more efficient input handling while also not having to drag every single TileInspector.cs into the Player's input component.