### PR TITLE
Fixed Infinite Mana Bug

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
@@ -1368,7 +1368,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9908a1708c744e844bf7e2a979c0f3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SelectableCube
-  tileType: 0
+  tileType: 2
   startingGridX: 0
   startingGridZ: 0
   gridX: 5
@@ -3473,7 +3473,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c25cdba096906e54bb7d84f6b69f698b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
-  startingMana: 10
+  startingMana: 3
   moveLeftUses: 2
   moveRightUses: 2
   moveForwardUses: 2

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/Puzzle1.prefab
@@ -1528,7 +1528,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9908a1708c744e844bf7e2a979c0f3f5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SelectableCube
-  tileType: 0
+  tileType: 2
   startingGridX: 0
   startingGridZ: 0
   gridX: 5
@@ -3543,16 +3543,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c25cdba096906e54bb7d84f6b69f698b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
-  startingMana: 10
-  manaLabel: {fileID: 4244620660118580199}
-  leftLabel: {fileID: 1230731256228544730}
-  upLabel: {fileID: 4247431490022177219}
-  downLabel: {fileID: 8218137926958000874}
-  rightLabel: {fileID: 7222528822434926062}
+  startingMana: 3
   moveLeftUses: 2
   moveRightUses: 2
   moveForwardUses: 2
   moveBackUses: 2
+  manaLabel: {fileID: 4244620660118580199}
+  leftLabel: {fileID: 1230731256228544730}
+  rightLabel: {fileID: 7222528822434926062}
+  upLabel: {fileID: 4247431490022177219}
+  downLabel: {fileID: 8218137926958000874}
   printStartingValues: 1
   printManaDeductions: 1
   printCardDeductions: 1

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -51,6 +51,9 @@ public class PlayerFixedMovement : MonoBehaviour
     /// </summary>
     private int destinationZ = 0;
 
+    private int lastTileX = int.MinValue;
+    private int lastTileZ = int.MinValue;
+
     private int deltaX;
     private int deltaZ;
 
@@ -90,6 +93,9 @@ public class PlayerFixedMovement : MonoBehaviour
 
     public static event Action<PuzzleInformation> updatePuzzleStatus;
 
+
+    private bool manaWellTriggeredThisEntry = false;
+
     private void Start()
     {
         rb = GetComponent<Rigidbody>();
@@ -101,7 +107,6 @@ public class PlayerFixedMovement : MonoBehaviour
         RuneCircle.puzzleTriggered += UpdatePuzzleInformation;
         ResetPuzzle.resetPuzzle += ResetPlayerPosition;
     }
-    
     // Unsubscribe from events
     private void OnDisable()
     {
@@ -364,45 +369,50 @@ public class PlayerFixedMovement : MonoBehaviour
     /// </summary>
     /// <param name="coordX"></param>
     /// <param name="coordZ"></param>
-    public void SnapPlayerToTile(int coordX, int coordZ)
+    public void SnapPlayerToTile(int coordX, int coordZ) 
     {
         // Grab the X and Z coordinates in Vector3 from the GridManager
-        newCoords = gridManager.GridToWorld(coordX, coordZ);
-        newPosition = new Vector3(newCoords.x, transform.localPosition.y, newCoords.z);
+    newCoords = gridManager.GridToWorld(coordX, coordZ);
+    newPosition = new Vector3(newCoords.x, transform.localPosition.y, newCoords.z);
 
-        if (printPlayerVector3)
-            Debug.Log($"PlayerFixedMovement.cs >> Player Vector3 Position: {newPosition}");
+    transform.localPosition = newPosition;
 
-        transform.localPosition = newPosition;
+    playerGridX = coordX;
+    playerGridZ = coordZ;
 
-        playerGridX = coordX;
-        playerGridZ = coordZ;
-        
-        if (printPlayerGridCoords)
-            Debug.Log($"PlayerFixedMovement.cs >> Player Grid Coordinates: ({coordX},{coordZ})");
-
+    // Only runs if tile is changed
+    if (coordX != lastTileX || coordZ != lastTileZ)
+    {
+        lastTileX = coordX;
+        lastTileZ = coordZ;
         // Handle tile effects (ManaWell, etc.)
         CheckTileEffects(coordX, coordZ);
+    }
 
-        IsPlayerOnEndTile();
+    IsPlayerOnEndTile();
     }
     
     /// <summary>
     /// Handles special tile effects such as ManaWell.
     /// </summary>
-    private void CheckTileEffects(int coordX, int coordZ)
+private void CheckTileEffects(int coordX, int coordZ)
+{
+    SelectableTile.TileType tileType = gridManager.GetTileType(coordX, coordZ);
+
+    if (tileType == SelectableTile.TileType.ManaWell)
     {
-        SelectableTile.TileType tileType = gridManager.GetTileType(coordX, coordZ);
+        
+        if (manaWellTriggeredThisEntry)
+            return;
 
-        if (tileType == SelectableTile.TileType.ManaWell)
-        {
-            Debug.Log("PlayerFixedMovement.cs >> Player stepped on ManaWell! +2 Mana");
+        manaWellTriggeredThisEntry = true;
 
-            if (resourceManager != null)
-                resourceManager.AddMana(2);
-        }
+        Debug.Log("PlayerFixedMovement.cs >> Player stepped on ManaWell! +2 Mana");
+
+        if (resourceManager != null)
+            resourceManager.AddMana(2);
     }
-    
+}    
     /// <summary>
     /// Used to check if the Player has reached the end tile. If so, the puzzle
     /// has been completed and the appropriate events can be triggered.

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs
@@ -10,6 +10,8 @@ using SimpleTimer;
 /// </summary>
 public class PuzzleFeedback : MonoBehaviour
 {
+    public static PuzzleFeedback Instance;
+
     [Title("UI Elements")]
     public GameObject feedbackPrefab;
     public TMP_Text onScreenText;
@@ -28,6 +30,17 @@ public class PuzzleFeedback : MonoBehaviour
     private float errorLastIntervalTime = 0f;
     private float errorInterval = 0.25f;
 
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+    private void OnDestroy()
+    {
+        if (Instance == this)
+            Instance = null;
+    }
+
     void Start()
     {
         // Hide popup text at start
@@ -40,6 +53,7 @@ public class PuzzleFeedback : MonoBehaviour
     {
         SelectableTile.cellOccupied += CellIsOccupied;
         SelectableTile.moveOutOfBounds += MoveIsOutOfBounds;
+        ResourceManager.noMoreCardUses += NoMoreCardUses;
     }
     
     // Unsubscribe from events
@@ -47,6 +61,7 @@ public class PuzzleFeedback : MonoBehaviour
     {
         SelectableTile.cellOccupied -= CellIsOccupied;
         SelectableTile.moveOutOfBounds -= MoveIsOutOfBounds;
+        ResourceManager.noMoreCardUses -= NoMoreCardUses;
     }
 
     private void CellIsOccupied(SelectableTile selectableTile)
@@ -57,6 +72,14 @@ public class PuzzleFeedback : MonoBehaviour
     private void MoveIsOutOfBounds(SelectableTile selectableTile)
     {
         StartFeedback(selectableTile, "You can't move outside the grid!");
+    }
+
+    /// <summary>
+    /// NEW: Triggered when player has no more card usages left
+    /// </summary>
+    private void NoMoreCardUses()
+    {
+        StartFeedback(null, "No more card usages!");
     }
 
     /// <summary>
@@ -77,9 +100,12 @@ public class PuzzleFeedback : MonoBehaviour
             originalColor = tileRenderer.material.color;
 
         // Reset interval timing every time an error happens
-        // Reset intervals
         errorLastIntervalTime = 0f;
         isFlashing = false;
+
+        // Stop previous timer if it exists
+        if (flickerTimer != null)
+            TimerManager.DeleteTimer(flickerTimer);
 
         // Show popup text
         if (onScreenText != null)
@@ -105,7 +131,11 @@ public class PuzzleFeedback : MonoBehaviour
         if (onScreenText != null)
             onScreenText.gameObject.SetActive(false);
 
-        TimerManager.DeleteTimer(flickerTimer);
+        if (flickerTimer != null)
+        {
+            TimerManager.DeleteTimer(flickerTimer);
+            flickerTimer = null;
+        }
     }
 
     private void OnTimerTick()

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
@@ -1,15 +1,19 @@
+using System;
 using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 
-// This script stores data regarding the resources provided during each puzzle.
-// Specifically, it keeps track of Mana points and available movement cards for
-// the Player to use. Note that it maintains a tight relationship with
-// TileSelector.cs to check resource availability for performing a move.
-
+/// <summary>
+/// This script stores data regarding the resources provided during each puzzle.
+/// Specifically, it keeps track of Mana points and available movement cards for
+/// the Player to use. Note that it maintains a tight relationship with
+/// TileSelector.cs to check resource availability for performing a move.
+/// </summary>
 public class ResourceManager : MonoBehaviour
 {
+    public static event Action noMoreCardUses;
+
     [Title("Resource Data", "Set the appropriate Mana and Move Card count for this puzzle.")]
     [PropertyTooltip("The starting Mana count. Set to 5 by default, but should be updated per puzzle.")]
     public int startingMana = 5;
@@ -35,7 +39,7 @@ public class ResourceManager : MonoBehaviour
     public TMP_Text rightLabel;
     public TMP_Text upLabel;
     public TMP_Text downLabel;
-    
+
     [Space]
     [Title("Debugging Options", "Settings for quick debugging options.")]
     [PropertyTooltip("Prints out the starting value for each resource. True by default.")]
@@ -49,7 +53,7 @@ public class ResourceManager : MonoBehaviour
 
     [PropertyTooltip("Print out when a specific movement card has no uses left. True by default.")]
     public bool printCardDrainage = true;
-    
+
     // Subscribe to events
     private void OnEnable()
     {
@@ -66,12 +70,15 @@ public class ResourceManager : MonoBehaviour
     {
         currentMana = startingMana;
 
-        if (printStartingValues) Debug.Log("ResourceManager.cs >> Starting Mana: " + currentMana);
-        if (printStartingValues) Debug.Log("ResourceManager.cs >> Starting Left Card Uses: " + moveLeftUses);
-        if (printStartingValues) Debug.Log("ResourceManager.cs >> Starting Right Card Uses: " + moveRightUses);
-        if (printStartingValues) Debug.Log("ResourceManager.cs >> Starting Up Card Uses: " + moveForwardUses);
-        if (printStartingValues) Debug.Log("ResourceManager.cs >> Starting Down Card Uses: " + moveBackUses);
-        
+        if (printStartingValues)
+        {
+            Debug.Log("ResourceManager.cs >> Starting Mana: " + currentMana);
+            Debug.Log("ResourceManager.cs >> Starting Left Card Uses: " + moveLeftUses);
+            Debug.Log("ResourceManager.cs >> Starting Right Card Uses: " + moveRightUses);
+            Debug.Log("ResourceManager.cs >> Starting Up Card Uses: " + moveForwardUses);
+            Debug.Log("ResourceManager.cs >> Starting Down Card Uses: " + moveBackUses);
+        }
+
         UpdateManaText(currentMana);
         UpdateLeftText(moveLeftUses);
         UpdateRightText(moveRightUses);
@@ -84,18 +91,15 @@ public class ResourceManager : MonoBehaviour
     /// Checks if the Player has enough resources before deducting anything.
     /// If a move is valid, return true. Otherwise, return false.
     /// </summary>
-    /// <param name="moveType"></param>
-    /// <returns></returns>
     public bool UseMove(string moveType)
     {
-        // Ensure that the Player has enough Mana to make a move
         if (currentMana <= 0)
         {
             Debug.Log("ResourceManager.cs >> No mana to move.");
+            PuzzleFeedback.Instance?.ShowMessage("No more mana!");
             return false;
         }
 
-        // Ensure that there's enough card uses for the specified move
         switch (moveType)
         {
             case "Left":
@@ -104,6 +108,8 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Left card uses remaining");
 
+                    PuzzleFeedback.Instance?.ShowMessage("No more Left card usages!");
+                    noMoreCardUses?.Invoke();
                     return false;
                 }
 
@@ -117,6 +123,8 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Right card uses remaining");
 
+                    PuzzleFeedback.Instance?.ShowMessage("No more Right card usages!");
+                    noMoreCardUses?.Invoke();
                     return false;
                 }
 
@@ -130,6 +138,8 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Forward card uses remaining");
 
+                    PuzzleFeedback.Instance?.ShowMessage("No more Forward card usages!");
+                    noMoreCardUses?.Invoke();
                     return false;
                 }
 
@@ -143,6 +153,8 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Back card uses remaining");
 
+                    PuzzleFeedback.Instance?.ShowMessage("No more Back card usages!");
+                    noMoreCardUses?.Invoke();
                     return false;
                 }
 
@@ -150,7 +162,7 @@ public class ResourceManager : MonoBehaviour
                 UpdateDownText(moveBackUses);
                 break;
         }
-        
+
         currentMana--;
 
         if (printManaDeductions)
@@ -163,7 +175,7 @@ public class ResourceManager : MonoBehaviour
 
         return true;
     }
-    
+
     /// <summary>
     /// Adds mana (used for ManaWell tiles).
     /// </summary>
@@ -176,20 +188,18 @@ public class ResourceManager : MonoBehaviour
 
         UpdateManaText(currentMana);
     }
-    
+
     /// <summary>
     /// Returns the current Mana count.
     /// </summary>
-    /// <returns></returns>
     public int GetMana()
     {
         return currentMana;
     }
-    
+
     /// <summary>
     /// Updates the Mana text on the UI.
     /// </summary>
-    /// <param name="amount"></param>
     private void UpdateManaText(int amount)
     {
         manaLabel.text = $"Mana\n{amount}";
@@ -198,7 +208,6 @@ public class ResourceManager : MonoBehaviour
     /// <summary>
     /// Updates the Left card uses text on the UI.
     /// </summary>
-    /// <param name="amount"></param>
     private void UpdateLeftText(int amount)
     {
         leftLabel.text = amount.ToString();
@@ -207,7 +216,6 @@ public class ResourceManager : MonoBehaviour
     /// <summary>
     /// Updates the Right card uses text on the UI.
     /// </summary>
-    /// <param name="amount"></param>
     private void UpdateRightText(int amount)
     {
         rightLabel.text = amount.ToString();
@@ -216,21 +224,19 @@ public class ResourceManager : MonoBehaviour
     /// <summary>
     /// Updates the Up card uses text on the UI.
     /// </summary>
-    /// <param name="amount"></param>
     private void UpdateUpText(int amount)
     {
         upLabel.text = amount.ToString();
     }
-    
+
     /// <summary>
     /// Updates the Down card uses text on the UI.
     /// </summary>
-    /// <param name="amount"></param>
     private void UpdateDownText(int amount)
     {
         downLabel.text = amount.ToString();
     }
-    
+
     /// <summary>
     /// Resets the Mana and movement card resources to their starting
     /// values. Called when the resetPuzzle event is triggered.

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
@@ -140,6 +140,10 @@ public class TileSelector : MonoBehaviour
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
 
+        // Ensure there are enough resources before attempting the move.
+        if (resourceManager.moveRightUses <= 0 || resourceManager.GetMana() <= 0)
+            return;
+
         // Only spend mana if the move actually succeeds
         if (selectedTile.TryMove(1, 0))
         {
@@ -157,6 +161,10 @@ public class TileSelector : MonoBehaviour
         if (selectedTile == null) return;
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
+
+        // Ensure there are enough resources before attempting the move.
+        if (resourceManager.moveLeftUses <= 0 || resourceManager.GetMana() <= 0)
+            return;
 
         // Only spend mana if the move actually succeeds
         if (selectedTile.TryMove(-1, 0))
@@ -176,6 +184,10 @@ public class TileSelector : MonoBehaviour
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
 
+        // Ensure there are enough resources before attempting the move.
+        if (resourceManager.moveForwardUses <= 0 || resourceManager.GetMana() <= 0)
+            return;
+
         // Only spend mana if the move actually succeeds
         if (selectedTile.TryMove(0, 1))
         {
@@ -193,6 +205,10 @@ public class TileSelector : MonoBehaviour
         if (selectedTile == null) return;
         if (PlayerOnSelectedTile()) return;
         if (SelectedTileIsStartOrEnd()) return;
+
+        // Ensure there are enough resources before attempting the move.
+        if (resourceManager.moveBackUses <= 0 || resourceManager.GetMana() <= 0)
+            return;
 
         // Only spend mana if the move actually succeeds
         if (selectedTile.TryMove(0, -1))


### PR DESCRIPTION
Fixed ManaWell so players only get mana when stepping onto the tile, instead of being able to farm mana by moving back and forth repeatedly. This keeps the tile effect working as intended without affecting normal movement or puzzle mechanics.