### PR TITLE
Hotfix | Restored [ExecuteAlways] Fail-safe

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/GridManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/GridManager.cs
@@ -4,7 +4,13 @@ using Sirenix.OdinInspector;
 using UnityEditor.Rendering;
 using UnityEngine;
 
-[ExecuteAlways]
+// NOTE: The [ExecuteAlways] should ONLY ever be uncommented to accurately place
+// puzzles in the scene. This is because tiles are distributed at runtime, so it's
+// hard to know where they will actually end up. However, for accurate testing of
+// the puzzle system, this could be commented out since it affects the resource
+// system and other data.
+//
+// [ExecuteAlways]
 public class GridManager : MonoBehaviour
 {
     [Space]

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
@@ -2,7 +2,13 @@ using System;
 using Sirenix.OdinInspector;
 using UnityEngine;
 
-[ExecuteAlways]
+// NOTE: The [ExecuteAlways] should ONLY ever be uncommented to accurately place
+// puzzles in the scene. This is because tiles are distributed at runtime, so it's
+// hard to know where they will actually end up. However, for accurate testing of
+// the puzzle system, this could be commented out since it affects the resource
+// system and other data.
+//
+// [ExecuteAlways]
 public class SelectableTile : MonoBehaviour
 {
     public enum TileType


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`hotfix/299-remove-ghost-tiles-on-reset`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/299-remove-ghost-tiles-on-reset) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR is posthumously related to #299.

### In-depth Details
- @cassdaw just resolved an issue with the occupancy map in [#390](https://github.com/Precipice-Games/untitled-26/pull/390).
- However, I noticed that this wiped the [ExecuteAlways] fail-safe I added with @mannykun in [#373](https://github.com/Precipice-Games/untitled-26/pull/373).
- Restored that commented-out line and the block of information above it (f612f2b).