### PR TITLE
Hotfix | Restored Clicking in Puzzle Mode on Oasis Island

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -13738,7 +13738,7 @@ PrefabInstance:
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[33].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1925510605}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[1].m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
@@ -14551,6 +14551,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9c1e2f0d10f1a4248ae2cc8220bf8fd7, type: 3}
+--- !u!114 &1925510605 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2708005216323003206, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+  m_PrefabInstance: {fileID: 895975369}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65197e0c65b7b8343ae036d2df089ea7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::InputManager
 --- !u!1001 &1979005613
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`hotfix/tile-selection-oaisis`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/tile-selection-oaisis) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR introduces a hotfix that is posthumously related to #290.

### In-depth Details
- In [#292](https://github.com/Precipice-Games/untitled-26/pull/292), I improved the input handling mechanism by converting what @mannykun put in the Update() method into an InputActions.CallbackContext.
- Due to limitations with the script itself, I outsourced the event to InputManager.cs.
- InputManager.cs then fires an event that informs SelectableTile.cs of a left click / selection event.
- Likewise, I just resolved the "no selection of tiles" bug in Oasis_Island.unity.


https://github.com/user-attachments/assets/0e3bfdc5-267c-4b18-92a0-90e27e53e86e