### PR TITLE
Fixed #325 | Ensure Proper Exiting From All UI Views

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Managers/GameStateManager.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Managers/GameStateManager.prefab
@@ -7073,6 +7073,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3072295140869992295, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
+      propertyPath: m_TagString
+      value: Paused
+      objectReference: {fileID: 0}
     - target: {fileID: 3098618309496679430, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4278190080

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/Buttons/UIChangerButton.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/Buttons/UIChangerButton.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -13,6 +14,7 @@ public class UIChangerButton : MonoBehaviour
     /// </summary>
     private GameObject currentUI;
 
+    public static event Action<bool> optionsMenuToggled;
 
     public void swapUI()
     {
@@ -23,7 +25,17 @@ public class UIChangerButton : MonoBehaviour
             currentUI.SetActive(false);
         }
 
-        targetUI.SetActive(true);
+        // If the target UI is not the initial paused menu, trigger the optionsMenuToggled event.
+        // This will ensure that you can't unpause the game by pressing 'esc' UNLESS you are on that one pause menu.
+        if (targetUI.gameObject.CompareTag("Paused"))
+        {
+            optionsMenuToggled?.Invoke(true);
+        }
+        else
+        {
+            optionsMenuToggled?.Invoke(false);
+        }
+            targetUI.SetActive(true);
         Debug.Log($"ViewManager.cs >> Enabled UI Canvas: {targetUI}");
     }
 

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
@@ -77,6 +77,7 @@ public class GameStateManager : MonoSingleton<GameStateManager>
         SceneManager.sceneLoaded += OnSceneLoaded;
         SceneManager.activeSceneChanged += OnActiveSceneChanged;
         ExitPuzzleButton.exitPuzzle += TransitionToState;
+        UIChangerButton.optionsMenuToggled += TogglePause;
     }
     
     private void OnDisable()
@@ -84,6 +85,7 @@ public class GameStateManager : MonoSingleton<GameStateManager>
         SceneManager.sceneLoaded -= OnSceneLoaded;
         SceneManager.activeSceneChanged -= OnActiveSceneChanged;
         ExitPuzzleButton.exitPuzzle -= TransitionToState;
+        UIChangerButton.optionsMenuToggled -= TogglePause;
     }
     
     // Runs when a scene is loaded
@@ -140,27 +142,27 @@ public class GameStateManager : MonoSingleton<GameStateManager>
         switch (newState)
         {
             case GameState.MainMenu:
-                pausable = false;
+                TogglePause(false);
                 Time.timeScale = 0.0f;
                 break;
             case GameState.Exploration:
-                pausable = true;
+                TogglePause(true);
                 Time.timeScale = 1.0f;
                 break;
             case GameState.Puzzle:
-                pausable = true;
+                TogglePause(true);
                 Time.timeScale = 1.0f;
                 break;
             case GameState.Dialogue:
-                pausable = true;
+                TogglePause(true);
                 Time.timeScale = 1.0f;
                 break;
             case GameState.Paused:
-                pausable = true;
+                TogglePause(true);
                 Time.timeScale = 0.0f;
                 break;
             case GameState.Settings:
-                pausable = false;
+                TogglePause(false);
                 Time.timeScale = 0.0f;
                 break;
         }
@@ -179,7 +181,7 @@ public class GameStateManager : MonoSingleton<GameStateManager>
     /// </summary>
     public void onPause()
     {
-        if (CurrentGameState == GameState.Paused)
+        if (CurrentGameState == GameState.Paused && pausable)
         {
             // Possible previous states should be Exploration, Puzzle, and Dialogue.
             TransitionToState(prevState);
@@ -235,5 +237,10 @@ public class GameStateManager : MonoSingleton<GameStateManager>
     public void ExitGame()
     {
         Application.Quit();
+    }
+
+    public void TogglePause(bool isPausable)
+    {
+        pausable = isPausable;
     }
 }

--- a/00 Unity Proj/Untitled-26/ProjectSettings/TagManager.asset
+++ b/00 Unity Proj/Untitled-26/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - Ground
+  - Paused
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Overview
- Pulling the latest version of [`issue/325-ensure-proper-exiting-from-pause-menu-for-all-ui-views`](https://github.com/Precipice-Games/untitled-26/issues/325) into [`dev`](https://github.com/Precipice-Games/untitled-26.git)
- Fixes #325 

In-Depth Details
- Created a method TogglePause in GameStateManager.cs to centralize toggling of pausable states.
- UIChangerButton.cs now invokes the optionsMenuToggled event that TogglePause() listens to.
- optionsMenuToggled sends either true or false based on if UI Menus can be unpaused from. This ensures that you can only unpause from the paused UI. 
- You CANNOT unpause from audio, controls, or options, and must go back to the initial paused menu to unpause the game using either the exit button or pressing 'esc'.