### PR TITLE
Fixed #399 | Finalized Ice Island Dialogue

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/IceIsland.yarn
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/IceIsland.yarn
@@ -1,4 +1,4 @@
-title: Judith
+﻿title: Judith
 position: -92,80
 ---
 <<declare $iceFinished = false>>
@@ -18,63 +18,19 @@ Sky: I’m Sky, it’s nice to meet you! What's your name? #line:027966d
 
 Sky: Well, actually, I was hoping you might be able to help me! #line:06c7301 
 
-Judith: No.  #line:04bff33 
+Judith: No. I'm busy.  #line:0d56923 
 
-Sky: But you don’t even know what I need help with. #line:0e4fb34 
+Sky: But you don’t even know what I need help with. #line:0e4fb34
 
-Judith: Don’t care. Not my problem. I have other things to worry about.  #line:0d0e734 
+Judith: Not my problem. I have other things to worry about.  #line:0d0e734 
 
 Sky: Like what? #line:052d7f2 
 
-Judith: My ice. #line:07cf835 
+Judith: Look, I'm busy right now. If you want to talk, you’ll have to meet me on the other side of this river. Otherwise, just leave me be. #line:0d9245b 
 
-Sky: Your ice? #line:0d2e025 
+Sky: Okay! But…how do I get across? #line:0c2dec9 
 
-Judith: Yes MY ICE! By the lake.  #line:01b25e2 
-
-Sky: What are you doing with your ice? #line:0514adb 
-
-Judith: Mining it, obviously. #line:04b45ee 
-
-Sky: Why? #line:0d35ab4 
-
-Judith: Do you always ask so many questions? #line:0129655 
-
-Sky: I’ve been told I’m very curious. #line:0994850 
-
-Judith: Yes, well, it’s distracting. Please leave me alone so I can continue my work. I’ve got to practice. The crystal’s not gonna free itself… #line:0218d4a 
-
-Sky: Wait a minute. Did you say crystal?! #line:0c0455d 
-
-Judith: Yes. The crystal that’s been trapped in this big block of ice since the fracture. Why do you sound so surprised? You act like you don’t live here… #line:02ae30b 
-
-Sky: I don’t actually. I’m from the Mother island! #line:0561efd 
-
-Judith: Hah. Good one. #line:049392f 
-
-Sky: No, I’m serious! My sky ship is right over there if you don’t believe me. #line:0cf98ac 
-
-Judith: … #line:0c26e84 
-Judith: That…that’s not possible. That shouldn’t be possible, travel between the islands hasn’t existed since the Fracture. #line:02a8a6c 
-
-Sky: And technically that’s still true, I’m just a bit of a…special circumstance. #line:0774467 
-
-Sky: The Mother Crystal has sent me on a quest to reunite the islands of Ethor…which is why I need your help. #line:08fb3c7 
-
-Judith: That’s– Ugh! What a load of hogwash. The islands are split apart, and they can’t be brought back together. This is how we live now. #line:00109e5 
-
-Sky: But it doesn’t have to be! Look, you don’t have to believe me. But at least let me try. I have the power to reactivate the crystal and bring this island back to the mainland! #line:0151cab 
-
-Judith: … #line:0bde927 
-
-Sky: At least let me try.  #line:0fddf07 
-
-Judith: Hmph. Whatever, it’s none of my business. Crystal is straight ahead, underneath that mountain. I don’t know how you’re gonna get there, though. #line:01c7bf2 
-
-Sky: Leave that to me! It was nice to meet you, Judith. Take care. #line:006144a 
-
-Judith: Hmph. You too. I guess. #line:053da1c 
-
+Judith: Not my problem. #line:06f83db 
 //Judith returns to mining the ice around her. You start on your journey toward the crystal.
 
 //(If the character goes back to Judith before activating the Crystal, she will say this:)
@@ -85,33 +41,121 @@ Judith: Back already? I knew you were full of it. #line:0b97180
 //(After reactivating the crystal, if the player returns to Judith and talks to her)
 <<if $iceFinished == true>>
 <<once>>
-Sky: I told you I could do it! #line:04367d8 
+Judith: Sky! what'd you do!?! The whole island is going crazy right now! #line:0a8ba5d 
 
-Judith: I…I don’t believe it. #line:0053f69 
-Judith: … #line:08ba995 
-Judith: Thank you. #line:0c874de 
+Sky: It's the island's crystal Judith, it's finally free! #line:011c394 
 
-Sky: Of course, Judith. I hope things can get a little easier for you now. #line:08a7e1f 
+Judith: Seriously? Jeez, maybe you could've given me a bit of a warning. #line:09b67ee 
 
-Judith: You’re going to go to all the islands, right? #line:0fb6aac 
+Sky: Yeah, sorry about that. I didn't know the crystal would react like that. #line:0fb5a01 
 
-Sky: That’s the plan. #line:014af39 
+Judith: So what does that mean for the island? Are things going to go back to normal? #line:0781f29 
 
-Judith: Good. That’s good. #line:0427171 
-Judith: I don’t know the specifics, but I’m sure they also have problems related to their crystals. #line:084e841 
-Judith: Make sure you talk to them.  #line:0035258 
+Sky: Well your island is back to how it was before the fracture…but we have a long way to go before things can be normal again. #line:082277b 
 
-Sky: Can do. #line:07c9cc3 
+Judith: What does that mean for you? #line:0da9b0e 
 
-Sky: I wish you the best, Judith. #line:03fce81 
+Sky: It means that I'm off to my next island. There are still those out there that are being affected by the Fracture. #line:08dc97a 
+Sky: I don't know what I'll find when I get there but I know that the Mother Crystal will guide me. #line:0e22dab 
 
-Judith: You too. And I really do mean that. #line:03ad7d2 
+Judith: Do you really think that you can fix all the islands from the fracture? #line:0084e9f 
+
+Sky: I know I can. Come on, don't you trust me at this point? #line:04b9a10 
+
+Judith: Well…thanks to I've got my island back to normal. I’m afraid to say that I do. I trust you Sky. And I thank you. #line:03f729f 
+
+Sky: Of course, Judith. I’m glad I was able to help you. Now, I'd better get going on those islands! They aren't going to fix themselves. #line:02c7354 
+
+Judith: If you ever need anything don't hesitate to ask. It's the least we can do to repay you for all you have done for us. #line:0aec0e8 
+
+Sky: Absolutely. Maybe one day I can come back and visit? #line:0f9faa0 
+
+Judith: Let’s not get ahead of ourselves. Goodbye, Sky…and safe travels. #line:041bc2a 
 
 //Player can walk away. If they click on Judith again, it will say:
 <<else>>
 Judith: Best of luck on your journey. I’m sure you’re gonna need it. #line:063507c 
 <<endonce>>
 <<endif>>
+===
+
+title: MountainJudith
+// Occurs after you have taken some kind of action towards the completion of the puzzle but haven't completed it
+---
+<<once>>
+Judith: I see that you've started to take a crack at getting this crystal free. #line:0322ba2 
+
+Sky: Yeah, well, like you said…the crystal being down makes it hard to live here. But, you shouldn’t have to leave. This is your home. I want to help make it the place it once was.  #line:0df41b7 
+
+Judith: Ha, well I wish the people on the mainland felt as passionate about us as you do. #line:09fc558 
+
+Sky: Once the crystal is out of there you won't have to concern yourself with all that. #line:0b98597 
+
+Judith: Thanks Sky. I won't forget this. #line:09b6e63 
+
+Sky: Don't mention it. #line:0829a44 
+<<else>>
+=>Judith: Oh look who it is, the mysterious traveler has arrived. Thought you'd got yourself lost in the snow. #line:00a2771 
+    Sky: You still don't believe I'm from the Mother Island? #line:078422c 
+
+    Judith: About as much as I believe you can get the crystal working again. What makes you so special anyway? #line:0515421 
+
+    Sky: I don't really know, if I’m honest. But I've been chosen for this task and I'm going to see it through, with or without your help. #line:01fad7d 
+
+    Judith: Alright, easy now. Let's not get all riled up. #line:0aeb77a 
+    Judith: Look, the crystal has been buried underneath the ice ever since the Fracture happened. Normally I'd easily be able to break it out, but something's off about the ice now. #line:0dee4cf 
+
+    Sky: What do you mean? #line:0fee148 
+
+    Judith: No matter how hard I try, the ice won't break. It's like the crystal has sort of sealed itself inside and is in no rush to leave. Maybe it was just waiting on something. #line:0a6c06b 
+
+    Sky: Oh, so are you finally starting to believe? #line:00b18bf 
+
+    Judith: Well, considering you're really the only one who seems to have a grasp of what's going on with it. Probably best to just let you have at it. #line:036f3f9 
+
+    Sky: Wow, some endorsement that is. You really know how to give a girl some encouragement. #line:0cf74f3 
+    Sky: Anyway, I better get going. That crystal isn't going to free itself. #line:0b05b79 
+
+    Judith: I'll be here if you need me. #line:090ce9c 
+=> Sky: So what's the deal with the penguins on this island? #line:0ebc06b 
+
+    Judith: The penguins? You came all the way up here to ask me about penguins? #line:05ab11f 
+
+    Sky: Well they're weird they stare at me and squawk a bunch. It's like they're trying to tell me something. #line:0847fb8 
+
+    Judith: Well, they are penguins after all, I always just kind of ignored them or gave them a quick 'hi' in passing. #line:0dee4f9 
+
+    Sky: Do you think they're trying to talk to us? Maybe they know something about the crystal we don't. #line:0e05ddc 
+
+    Judith: I am curious what they would have to say for themselves if they could speak our language…but who knows. #line:03361ae 
+    Judith: If there is anything that we don't have a shortage of around here, it is our penguins. You’ll never run out of conversation. #line:09c3f30 
+
+    Sky: I'd bet they'd have some pretty good stories to tell about the island. #line:0f06a8f 
+
+    Judith: Maybe. Anyway, let me get back to what I'm doing. See you later, Sky. #line:050e863 
+
+    Sky: See you later, Judith. #line:03fdd5b 
+=>Sky: What's the deal with your trees on this island? #line:02afcdb 
+
+    Judith: What's wrong with the trees we have here? #line:03a1dff 
+
+    Sky: Nothing, nothing. I’ve just never seen anything like them. #line:011e084 
+
+    Judith: They’re a special kind of tree. They’ve had to adapt to the cold weather, so they don’t lose their leaves regardless of the season. That way they can continue to grow all year long. Pretty neat, huh? #line:00379f9 
+
+    Sky: Yeah, it is! I’m so excited to see the ways in which all the islands are different. Especially the weather! It’s only ever sunny and warm back home.  #line:024e4cc 
+
+    Judith: Hm, yeah. I'm curious how the other islands are handling all of this. Wonder how their crystals reacted to the Fracture. #line:0746bf9 
+
+    Sky: Each crystal is special in its own way, so I'd imagine the effects are different per island. At least, that’s what the Mother Crystal told me. #line:0f6276b 
+
+    Judith: If the crystal can affect the ice maybe it can affect the trees too… #line:0395f02 
+    Judith: Who knows? Maybe they can help you with getting the crystal free. #line:0095932 
+
+    Sky: Hm, that's possible…I'll keep it in mind. Thanks Judith. #line:0d41577 
+
+    Judith: Hmph. You’re welcome. #line:0262019 
+<<endonce>>
 ===
 
 title: Penguin

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/IceIsland.yarn
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/IceIsland.yarn
@@ -81,8 +81,9 @@ Judith: Hmph. You too. I guess. #line:053da1c
 <<else>>
 Judith: Back already? I knew you were full of it. #line:0b97180 
 <<endonce>>
+<<endif>>
 //(After reactivating the crystal, if the player returns to Judith and talks to her)
-<<else>>
+<<if $iceFinished == true>>
 <<once>>
 Sky: I told you I could do it! #line:04367d8 
 
@@ -144,4 +145,45 @@ position: -256,-126
 =>Penguin: Squawk! (Why do we live just to die?) #line:007c292 
     Sky: Awww look at this cute little fella! Not a single thought behind those eyes! #line:09af056 
     Penguin: Squuuaaawwk! (Your story will turn its final page one day whether you like it or not!) #line:0d2c4e4 
+===
+
+title: Player
+---
+Sky: This place is quite beautiful, despite the cold. [Idle] #line:0d2c4e5
+
+Sky: Brr, it sure is cold, I should find a parka or something. [Without interaction, while moving] #line:0d2c4e6
+
+Sky: Ughhh, so chilly! Why didn’t I check the weather before coming here? [Without interaction, while moving] #line:0d2c4e7
+
+Sky: Gah! If this wind keeps up I may start drifting away like a plastic bag! [Idle] #line:0d2c4e8
+
+Sky: Gotta keep moving to stay warm!  [Without interaction, while moving] #line:0d2c4e9
+
+Sky: Who needs a coat anyways? Definitely not me. Somebody please bring me a coat    [Idle] #line:09af057
+
+Sky: I wish I could feel the snow crunching beneath my feet… if only I could feel my feet. [Without interaction, while moving] #line:09af058
+
+Sky: It sure is gorgeous out here, I just wish the cold would stop hogging the spotlight.  [Idle] #line:09af059
+
+Sky: Brrr… I’m gonna turn into a human popsicle if I stand around here. [Idle] #line:013e3c6
+
+Sky: Grrrr… My teeth feel like a symphony of jackhammers. [Idle] #line:013e3c7
+
+Sky: Is this what it feels like to be freezer food? [Idle] #line:013e3c8
+
+Sky: If only my warm thoughts would warm me up… [Idle] #line:013e3c9
+
+Sky: Better watch my step, I could slip and fall at any given moment! [Without interaction, while moving] #line:04ccf12
+
+Sky: I’d give anything for a blanket right now. [Idle] #line:04ccf13
+
+Sky: I don’t get how penguins can walk around in the cold like this all day. [Without interaction, while moving] #line:04ccf14
+
+Sky: Brr, did the temperature drop another ten degrees? [Idle] #line:04ccf15
+
+Sky: Is it normal to shiver this much or am I being too dramatic? [Without interaction, while moving] #line:04ccf16
+
+Sky: This is the worst case of brain freeze EVER! [Without interaction, while moving] #line:04ccf17
+
+Sky: This place feels like I’m walking inside a massive snow globe!  [Without interaction, while moving] #line:04ccf18
 ===

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable Shared Data.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable Shared Data.asset
@@ -1036,6 +1036,82 @@ MonoBehaviour:
     m_Metadata:
       m_Items:
       - rid: 1731521079247372364
+  - m_Id: 17945639788081152
+    m_Key: line:0d2c4e5
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945643336462336
+    m_Key: line:0d2c4e6
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945644775108608
+    m_Key: line:0d2c4e7
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945645576220672
+    m_Key: line:0d2c4e8
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945646394109952
+    m_Key: '#line:0d2c4e9'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945647090364416
+    m_Key: line:09af057
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945647820173312
+    m_Key: line:09af058
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945648537399296
+    m_Key: line:09af059
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945649376260096
+    m_Key: line:013e3c6
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945650148012032
+    m_Key: line:013e3c7
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945651653767168
+    m_Key: line:013e3c8
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945653029498880
+    m_Key: line:013e3c9
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945740350713856
+    m_Key: line:04ccf12
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945741030191104
+    m_Key: "line:04ccf13\t\t"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945741722251264
+    m_Key: line:04ccf14
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945742405922816
+    m_Key: line:04ccf16
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945745371295744
+    m_Key: line:04ccf17
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945748768681984
+    m_Key: line:04ccf18
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17946927028367360
+    m_Key: line:04ccf15
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable_en.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable_en.asset
@@ -903,6 +903,90 @@ MonoBehaviour:
     m_Localized: 'King Julien: GO FINISH YOUR MISSION TRESSPASSER!'
     m_Metadata:
       m_Items: []
+  - m_Id: 17945639788081152
+    m_Localized: 'Sky: This place is quite beautiful, despite the cold.'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945643336462336
+    m_Localized: 'Sky: Brr, it sure is cold, I should find a parka or something.'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945644775108608
+    m_Localized: "Sky: Ughhh, so chilly! Why didn\u2019t I check the weather before
+      coming here?"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945645576220672
+    m_Localized: 'Sky: Gah! If this wind keeps up I may start drifting away like
+      a plastic bag!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945646394109952
+    m_Localized: 'Sky: Gotta keep moving to stay warm!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945647090364416
+    m_Localized: 'Sky: Who needs a coat anyways? Definitely not me. Somebody please
+      bring me a coat'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945647820173312
+    m_Localized: "Sky: I wish I could feel the snow crunching beneath my feet\u2026
+      if only I could feel my feet."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945648537399296
+    m_Localized: 'Sky: It sure is gorgeous out here, I just wish the cold would stop
+      hogging the spotlight'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945649376260096
+    m_Localized: "Sky: Brrr\u2026 I\u2019m gonna turn into a human popsicle if I
+      stand around here."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945650148012032
+    m_Localized: "Sky: Grrrr\u2026 My teeth feel like a symphony of jackhammers."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945651653767168
+    m_Localized: 'Sky: Is this what it feels like to be freezer food?'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945653029498880
+    m_Localized: "Sky: If only my warm thoughts would warm me up\u2026"
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945740350713856
+    m_Localized: 'Sky: Better watch my step, I could slip and fall at any given moment!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945741030191104
+    m_Localized: "Sky: I\u2019d give anything for a blanket right now."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945741722251264
+    m_Localized: "Sky: I don\u2019t get how penguins can walk around in the cold
+      like this all day."
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945742405922816
+    m_Localized: 'Sky: Is it normal to shiver this much or am I being too dramatic?'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945745371295744
+    m_Localized: 'Sky: This is the worst case of brain freeze EVER!'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17946927028367360
+    m_Localized: 'Sky: Brr, did the temperature drop another ten degrees?'
+    m_Metadata:
+      m_Items: []
+  - m_Id: 17945748768681984
+    m_Localized: "Sky: This place feels like I\u2019m walking inside a massive snow
+      globe!"
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable_zh-Hans.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/Localization/LineTable_zh-Hans.asset
@@ -17,7 +17,11 @@ MonoBehaviour:
   m_SharedData: {fileID: 11400000, guid: c884be7acc7ff0f4db5cf6f4614ad1f2, type: 2}
   m_Metadata:
     m_Items: []
-  m_TableData: []
+  m_TableData:
+  - m_Id: 17945649376260096
+    m_Localized: 
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Dialogue/Dialogue System Variant.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Dialogue/Dialogue System Variant.prefab
@@ -170,15 +170,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7985477256237130417, guid: 52571f68872914e24837210513edea1d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 7.55253
       objectReference: {fileID: 0}
     - target: {fileID: 7985477256237130417, guid: 52571f68872914e24837210513edea1d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.03715
       objectReference: {fileID: 0}
     - target: {fileID: 7985477256237130417, guid: 52571f68872914e24837210513edea1d, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -7.9845
       objectReference: {fileID: 0}
     - target: {fileID: 7985477256237130417, guid: 52571f68872914e24837210513edea1d, type: 3}
       propertyPath: m_LocalRotation.w
@@ -287,7 +287,7 @@ PrefabInstance:
     - target: {fileID: 8309902628685535410, guid: 52571f68872914e24837210513edea1d, type: 3}
       propertyPath: lineProvider
       value: 
-      objectReference: {fileID: 7008645686420830657}
+      objectReference: {fileID: 0}
     - target: {fileID: 8309902628685535410, guid: 52571f68872914e24837210513edea1d, type: 3}
       propertyPath: dialoguePresenters.Array.size
       value: 4

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -28697,7 +28697,7 @@ GameObject:
   - component: {fileID: 1351094001}
   - component: {fileID: 1351094000}
   m_Layer: 0
-  m_Name: Mountain Judith
+  m_Name: MountainJudith
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -28712,7 +28712,7 @@ Transform:
   m_GameObject: {fileID: 1351093998}
   serializedVersion: 2
   m_LocalRotation: {x: 0.010566138, y: -0.9590498, z: -0.021161918, w: 0.28224826}
-  m_LocalPosition: {x: 12.63, y: 11.75, z: 38.25}
+  m_LocalPosition: {x: 12.64, y: 10.05, z: 38.17}
   m_LocalScale: {x: 0.16819604, y: 0.1681961, z: 0.16819602}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -29471,68 +29471,16 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: 'dialoguePresenters.Array.data[3]'
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
       propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1604888279}
     - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
       propertyPath: onDialogueComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 1604888279}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: onDialogueComplete.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: onDialogueTrigger
-      objectReference: {fileID: 0}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: onDialogueStart.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: toggleRotation
-      objectReference: {fileID: 0}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: onDialogueComplete.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: onDialogueTrigger
-      objectReference: {fileID: 0}
-    - target: {fileID: 7083096844073325273, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: onDialogueComplete.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: toggleRotation
-      objectReference: {fileID: 0}
     - target: {fileID: 8491125579856222884, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
       propertyPath: m_Name
       value: Dialogue System
-      objectReference: {fileID: 0}
-    - target: {fileID: 8580778807943748390, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8580778807943748390, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8580778807943748390, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8580778807943748390, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8580778807943748390, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8580778807943748390, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9101912181687942934, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
       propertyPath: m_AnchorMax.y
@@ -44204,6 +44152,14 @@ PrefabInstance:
       propertyPath: variableStorage
       value: 
       objectReference: {fileID: 977928730}
+    - target: {fileID: 2256523913752244413, guid: 34e361e532974434c8ac75f1dc46faf2, type: 3}
+      propertyPath: crystalCollected
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2256523913752244413, guid: 34e361e532974434c8ac75f1dc46faf2, type: 3}
+      propertyPath: allPuzzlesCompleted
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2256523913752244413, guid: 34e361e532974434c8ac75f1dc46faf2, type: 3}
       propertyPath: islandPuzzleManager
       value: 

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -28690,7 +28690,7 @@ GameObject:
   - component: {fileID: 1351094001}
   - component: {fileID: 1351094000}
   m_Layer: 0
-  m_Name: Mountain Judith
+  m_Name: MountainJudith
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -28705,7 +28705,7 @@ Transform:
   m_GameObject: {fileID: 1351093998}
   serializedVersion: 2
   m_LocalRotation: {x: 0.010566138, y: -0.9590498, z: -0.021161918, w: 0.28224826}
-  m_LocalPosition: {x: 12.63, y: 11.75, z: 38.25}
+  m_LocalPosition: {x: 12.64, y: 10.04, z: 38.17}
   m_LocalScale: {x: 0.16819604, y: 0.1681961, z: 0.16819602}
   m_ConstrainProportionsScale: 1
   m_Children: []

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -14128,6 +14128,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 9102834559974394949, guid: ff16e4e71610ade4bb5e6805e7db56e3, type: 3}
   m_PrefabInstance: {fileID: 8600581230760321559}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &607449464 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7407150238594421454, guid: 8a4743623ff36b94f9f8e976cda3a878, type: 3}
+  m_PrefabInstance: {fileID: 1422275508}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 610c541718d694070a21327d1ae62e75, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &611145321 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3796191418792194300, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
@@ -18917,20 +18928,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8014860526984270938, guid: 52fcc2c214e11dd46bc310e39123907a, type: 3}
   m_PrefabInstance: {fileID: 977543472}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &977928730
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 610c541718d694070a21327d1ae62e75, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  showDebug: 0
-  debugTextView: {fileID: 0}
 --- !u!1001 &978103889
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -44151,7 +44148,7 @@ PrefabInstance:
     - target: {fileID: 2256523913752244413, guid: 34e361e532974434c8ac75f1dc46faf2, type: 3}
       propertyPath: variableStorage
       value: 
-      objectReference: {fileID: 977928730}
+      objectReference: {fileID: 607449464}
     - target: {fileID: 2256523913752244413, guid: 34e361e532974434c8ac75f1dc46faf2, type: 3}
       propertyPath: crystalCollected
       value: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandManager.cs
@@ -25,9 +25,7 @@ public class IslandManager : MonoBehaviour
     public IslandName islandName = IslandName.IceIsland; // Default is Ice Island
     [PropertyTooltip("Attach the relevant data for this island's puzzles.")]
     public IslandPuzzleManager islandPuzzleManager;
-    // [PropertyTooltip("Attach the end crystal collectable for this island.")]
-    // public GameObject endCrystal;
-    [PropertyTooltip("Attach the InMemoryVariableStorage component from the DialogueSystem object.")]
+    [PropertyTooltip("Attach the DialogueSystem object here, which contains the InMemoryVariableStorage.")]
     public InMemoryVariableStorage variableStorage;
     
     [Space]
@@ -38,7 +36,7 @@ public class IslandManager : MonoBehaviour
     [SerializeField]private bool allPuzzlesCompleted;
     [SerializeField]private bool crystalCollected;
     // public static event Action<PuzzleInformation> islandCompleted;
-    
+
     /// <summary>
     /// Used to verify that all the current island's puzzles have been completed. Also
     /// updates the variable for the specified island in the YarnSpinner variable storage.
@@ -54,6 +52,7 @@ public class IslandManager : MonoBehaviour
                 break;
             case IslandName.IceIsland:
                 Debug.Log("IslandManager.cs >> Ice Island puzzles completed!");
+                Debug.Log("IslandManager.cs >> Test message here!");
                 variableStorage.SetValue("$iceFinished", true);
                 allPuzzlesCompleted = true;
                 break;

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandManager.cs
@@ -35,8 +35,8 @@ public class IslandManager : MonoBehaviour
     public UnityEvent islandCompleted;
     
     // Variables to track and update the island's completion status
-    private bool allPuzzlesCompleted;
-    private bool crystalCollected;
+    [SerializeField]private bool allPuzzlesCompleted;
+    [SerializeField]private bool crystalCollected;
     // public static event Action<PuzzleInformation> islandCompleted;
     
     /// <summary>

--- a/00 Unity Proj/Untitled-26/Untitled-26.slnx
+++ b/00 Unity Proj/Untitled-26/Untitled-26.slnx
@@ -1,0 +1,12 @@
+﻿<Solution>
+  <Project Path="Unity.InputSystem.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.UnityLocalization.Editor.csproj" />
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Unity.InputSystem.ForUI.csproj" />
+  <Project Path="Unity.InputSystem.TestFramework.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.Unity.Addressables.csproj" />
+  <Project Path="Unity.InputSystem.DocCodeSamples.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.UnityMathematics.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.UnityLocalization.csproj" />
+  <Project Path="Unity.InputSystem.IntegrationTests.csproj" />
+</Solution>


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/399-finalize-ice-island-dialogue`](https://github.com/Precipice-Games/untitled-26/tree/issue/399-finalize-ice-island-dialogue) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #399.

### In-depth Details
- Merging the work that @Agentx49 did in terms of finalizing the dialogue on Ice island.
- In 4844980, I had to reattach the DialogueSystem to the IslandManager in the scene.
- The IslandManager **requires** a reference to YarnSpinner's InMemoryVariableStorage component in order to update variables.