### PR TITLE
Fixed #404 | Improved SceneChangerButton & Corrected Build Order

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Managers/GameStateManager.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Managers/GameStateManager.prefab
@@ -7618,10 +7618,6 @@ PrefabInstance:
       value: Menu
       objectReference: {fileID: 0}
     - target: {fileID: 1384882117902596046, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
-      propertyPath: m_text
-      value: Menu
-      objectReference: {fileID: 0}
-    - target: {fileID: 1384882117902596046, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
       propertyPath: m_TextStyleHashCode
       value: -1183493901
       objectReference: {fileID: 0}
@@ -9205,7 +9201,7 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 805262423561156159}
     - targetCorrespondingSourceObject: {fileID: 8018635157453650121, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
-      insertIndex: -1
+      insertIndex: 7
       addedObject: {fileID: 2058018308299488618}
     - targetCorrespondingSourceObject: {fileID: -479779240224528538, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
       insertIndex: -1
@@ -9434,7 +9430,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60642b4dc867a2441a709bf5d508be9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SceneChangerButton
-  scene: MovementInteraction_1
+  nextDestination: 1
+  scene: <Insert scene name>
 --- !u!1 &7068722117972722226 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -544191721942471486, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
@@ -9452,7 +9449,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60642b4dc867a2441a709bf5d508be9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SceneChangerButton
-  scene: MainMenu
+  nextDestination: 1
+  scene: <Insert scene name>
 --- !u!1 &7150865741348096406 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -479779240224528538, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
@@ -9470,7 +9468,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60642b4dc867a2441a709bf5d508be9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SceneChangerButton
-  scene: Ice_Island
+  nextDestination: 1
+  scene: <Insert scene name>
 --- !u!224 &7598088730690286271 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8294034719170780239, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}
@@ -9503,7 +9502,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60642b4dc867a2441a709bf5d508be9a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SceneChangerButton
-  scene: Ice_Island
+  nextDestination: 1
+  scene: <Insert scene name>
 --- !u!1 &8742719022096561527 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -2071689421119120505, guid: 1cd89ea0c609ae947bf781193be976c9, type: 3}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/MainMenu.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/MainMenu.unity
@@ -970,7 +970,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3700156439328364526, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3739096238375276062, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/Buttons/SceneChangerButton.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/Buttons/SceneChangerButton.cs
@@ -1,12 +1,64 @@
+using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
+// This script is used for buttons that change the scene when pressed.
+// It contains an enum for a safer way to determine the next scene, as
+// opposed to just using a string.
+
 public class SceneChangerButton :  MonoBehaviour
 {
-    public string scene = "<Insert scene name>";
+    public enum SceneDestination
+    {
+        MainMenu,
+        MotherIsland,
+        IceIsland,
+        OasisIsland
+        
+        // Add flower island later
+    }
+    
+    [Title("SceneChanger Variables", "Variables related to scene switching.")]
+    [PropertyTooltip("The scene to load upon pressing this button.")]
+    public SceneDestination nextDestination = SceneDestination.MotherIsland; // Default is Mother Island
+    
+    // Placeholder string that will store name of next scene
+    private string scene = "scene";
 
+    /// <summary>
+    /// Called by LoadScene(). Returns a string that is the name of the
+    /// next scene to load, based on the value of nextDestination.
+    /// </summary>
+    /// <param name="destination"></param>
+    /// <returns></returns>
+    private string DetermineScene(SceneDestination destination)
+    {
+        switch (destination)
+        {
+            case SceneDestination.MainMenu:
+                scene = "MainMenu";
+                break;
+            case SceneDestination.MotherIsland:
+                scene = "Mother_Island";
+                break;
+            case SceneDestination.IceIsland:
+                scene = "Ice_Island";
+                break;
+            case SceneDestination.OasisIsland:
+                scene = "Oasis_Island";
+                break;
+        }
+        
+        return scene;
+    }
+    
+    /// <summary>
+    /// Calls DetermineScene() to get the name of the next scene to load.
+    /// Triggered by the button's OnClick() event in the Inspector.
+    /// </summary>
     public void LoadScene()
     {
-        SceneManager.LoadScene(scene);
+        var nextScene = DetermineScene(nextDestination);
+        SceneManager.LoadScene(nextScene);
     }
 }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/404-correct-build-order-for-alpha`](https://github.com/Precipice-Games/untitled-26/tree/issue/404-correct-build-order-for-alpha) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #404.

In-depth Details
- Merging only one commit that contains an improvement to SceneChangerButton.cs.
- This update also updated the build/load order in terms of how the scenes will flow.
     - Now, when we click New Game, we will go to Mother Island instead of Ice Island.
     - Still gluing together all the scenes with the airship in [#403](https://github.com/Precipice-Games/untitled-26/issues/403).
- The scene switching script previously took in a string that had to be entered manually in the Inspector.
     - I converted this into an Enum named SceneDestination.
- The button click still calls LoadScene(), but now it creates a local variable named scene, whose value is determinate by DetermineScene().
     - DetermineScene() parses the Enum variable and returns a string.
     - LoadScene() uses that string to load up the next scene.
- This is what it looks like in the Inspector.

<p>
<img src="https://github.com/user-attachments/assets/c4946484-cf99-4b61-a81a-1788469b790a" alt="NewSceneChangerButtonEnum" width="80%" style="max-width: 100%;">
</p>