### PR TITLE
Sprite sheet fixes

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Art/Animations/Player Animation Images/image sequence 2/Materials/image00.mat
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Animations/Player Animation Images/image sequence 2/Materials/image00.mat
@@ -25,7 +25,6 @@ Material:
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
-  - _ALPHAPREMULTIPLY_ON
   - _SURFACE_TYPE_TRANSPARENT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -104,7 +103,7 @@ Material:
     - _AlphaClip: 0
     - _AlphaToMask: 0
     - _Blend: 0
-    - _BlendModePreserveSpecular: 1
+    - _BlendModePreserveSpecular: 0
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
@@ -126,7 +125,7 @@ Material:
     - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 1
+    - _SrcBlend: 5
     - _SrcBlendAlpha: 1
     - _Surface: 1
     - _WorkflowMode: 1

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/JudithSpritesheet.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/JudithSpritesheet.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: JudithSpritesheet_0
       rect:
         serializedVersion: 2
-        x: 641
-        y: 13909
-        width: 645
-        height: 870
+        x: 0
+        y: 13440
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: JudithSpritesheet_1
       rect:
         serializedVersion: 2
-        x: 2561
-        y: 13909
-        width: 645
-        height: 870
+        x: 1920
+        y: 13440
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: JudithSpritesheet_2
       rect:
         serializedVersion: 2
-        x: 4481
-        y: 13909
-        width: 645
-        height: 870
+        x: 3840
+        y: 13440
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: JudithSpritesheet_3
       rect:
         serializedVersion: 2
-        x: 6401
-        y: 13909
-        width: 645
-        height: 870
+        x: 5760
+        y: 13440
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: JudithSpritesheet_4
       rect:
         serializedVersion: 2
-        x: 8314
-        y: 13909
-        width: 652
-        height: 870
+        x: 7680
+        y: 13440
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: JudithSpritesheet_5
       rect:
         serializedVersion: 2
-        x: 634
-        y: 11989
-        width: 652
-        height: 870
+        x: 0
+        y: 11520
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: JudithSpritesheet_6
       rect:
         serializedVersion: 2
-        x: 2546
-        y: 11989
-        width: 668
-        height: 870
+        x: 1920
+        y: 11520
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: JudithSpritesheet_7
       rect:
         serializedVersion: 2
-        x: 4459
-        y: 11989
-        width: 675
-        height: 870
+        x: 3840
+        y: 11520
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: JudithSpritesheet_8
       rect:
         serializedVersion: 2
-        x: 6379
-        y: 11989
-        width: 682
-        height: 870
+        x: 5760
+        y: 11520
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: JudithSpritesheet_9
       rect:
         serializedVersion: 2
-        x: 8291
-        y: 11989
-        width: 690
-        height: 870
+        x: 7680
+        y: 11520
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: JudithSpritesheet_10
       rect:
         serializedVersion: 2
-        x: 604
-        y: 10069
-        width: 705
-        height: 870
+        x: 0
+        y: 9600
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: JudithSpritesheet_11
       rect:
         serializedVersion: 2
-        x: 2524
-        y: 10069
-        width: 705
-        height: 870
+        x: 1920
+        y: 9600
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: JudithSpritesheet_12
       rect:
         serializedVersion: 2
-        x: 4444
-        y: 10069
-        width: 705
-        height: 870
+        x: 3840
+        y: 9600
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: JudithSpritesheet_13
       rect:
         serializedVersion: 2
-        x: 6356
-        y: 10069
-        width: 713
-        height: 870
+        x: 5760
+        y: 9600
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: JudithSpritesheet_14
       rect:
         serializedVersion: 2
-        x: 8276
-        y: 10069
-        width: 713
-        height: 870
+        x: 7680
+        y: 9600
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: JudithSpritesheet_15
       rect:
         serializedVersion: 2
-        x: 604
-        y: 8149
-        width: 705
-        height: 870
+        x: 0
+        y: 7680
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: JudithSpritesheet_16
       rect:
         serializedVersion: 2
-        x: 2531
-        y: 8149
-        width: 690
-        height: 870
+        x: 1920
+        y: 7680
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: JudithSpritesheet_17
       rect:
         serializedVersion: 2
-        x: 4459
-        y: 8149
-        width: 682
-        height: 870
+        x: 3840
+        y: 7680
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: JudithSpritesheet_18
       rect:
         serializedVersion: 2
-        x: 6386
-        y: 8149
-        width: 668
-        height: 870
+        x: 5760
+        y: 7680
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: JudithSpritesheet_19
       rect:
         serializedVersion: 2
-        x: 8314
-        y: 8149
-        width: 652
-        height: 870
+        x: 7680
+        y: 7680
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: JudithSpritesheet_20
       rect:
         serializedVersion: 2
-        x: 641
-        y: 6229
-        width: 645
-        height: 870
+        x: 0
+        y: 5760
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: JudithSpritesheet_21
       rect:
         serializedVersion: 2
-        x: 2561
-        y: 6229
-        width: 645
-        height: 870
+        x: 1920
+        y: 5760
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: JudithSpritesheet_22
       rect:
         serializedVersion: 2
-        x: 4481
-        y: 6229
-        width: 645
-        height: 870
+        x: 3840
+        y: 5760
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: JudithSpritesheet_23
       rect:
         serializedVersion: 2
-        x: 6394
-        y: 6229
-        width: 652
-        height: 870
+        x: 5760
+        y: 5760
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: JudithSpritesheet_24
       rect:
         serializedVersion: 2
-        x: 8314
-        y: 6229
-        width: 660
-        height: 870
+        x: 7680
+        y: 5760
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: JudithSpritesheet_25
       rect:
         serializedVersion: 2
-        x: 626
-        y: 4309
-        width: 675
-        height: 870
+        x: 0
+        y: 3840
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: JudithSpritesheet_26
       rect:
         serializedVersion: 2
-        x: 2541
-        y: 4309
-        width: 688
-        height: 870
+        x: 1920
+        y: 3840
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: JudithSpritesheet_27
       rect:
         serializedVersion: 2
-        x: 4459
-        y: 4309
-        width: 697
-        height: 870
+        x: 3840
+        y: 3840
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: JudithSpritesheet_28
       rect:
         serializedVersion: 2
-        x: 6379
-        y: 4309
-        width: 697
-        height: 870
+        x: 5760
+        y: 3840
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: JudithSpritesheet_29
       rect:
         serializedVersion: 2
-        x: 8299
-        y: 4309
-        width: 697
-        height: 870
+        x: 7680
+        y: 3840
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: JudithSpritesheet_30
       rect:
         serializedVersion: 2
-        x: 619
-        y: 2389
-        width: 697
-        height: 870
+        x: 0
+        y: 1920
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -821,10 +821,10 @@ TextureImporter:
       name: JudithSpritesheet_31
       rect:
         serializedVersion: 2
-        x: 2539
-        y: 2389
-        width: 697
-        height: 870
+        x: 1920
+        y: 1920
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -843,10 +843,10 @@ TextureImporter:
       name: JudithSpritesheet_32
       rect:
         serializedVersion: 2
-        x: 4459
-        y: 2389
-        width: 690
-        height: 870
+        x: 3840
+        y: 1920
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -865,10 +865,10 @@ TextureImporter:
       name: JudithSpritesheet_33
       rect:
         serializedVersion: 2
-        x: 6386
-        y: 2389
-        width: 683
-        height: 870
+        x: 5760
+        y: 1920
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -887,10 +887,10 @@ TextureImporter:
       name: JudithSpritesheet_34
       rect:
         serializedVersion: 2
-        x: 8306
-        y: 2389
-        width: 675
-        height: 870
+        x: 7680
+        y: 1920
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -909,10 +909,10 @@ TextureImporter:
       name: JudithSpritesheet_35
       rect:
         serializedVersion: 2
-        x: 634
-        y: 469
-        width: 667
-        height: 870
+        x: 0
+        y: 0
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -931,10 +931,10 @@ TextureImporter:
       name: JudithSpritesheet_36
       rect:
         serializedVersion: 2
-        x: 2554
-        y: 469
-        width: 660
-        height: 870
+        x: 1920
+        y: 0
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -953,10 +953,10 @@ TextureImporter:
       name: JudithSpritesheet_37
       rect:
         serializedVersion: 2
-        x: 4474
-        y: 469
-        width: 660
-        height: 870
+        x: 3840
+        y: 0
+        width: 1920
+        height: 1920
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -985,7 +985,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":5.0,"y":8.0},"gridSpriteSize":{"x":1920.0,"y":1920.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       JudithSpritesheet_0: 957181384
       JudithSpritesheet_1: -1194223155
@@ -1019,7 +1019,6 @@ TextureImporter:
       JudithSpritesheet_35: -2060477694
       JudithSpritesheet_36: -521705129
       JudithSpritesheet_37: -984214732
-      JudithSpritesheet_38: -1338905169
       JudithSpritesheet_4: -1595141373
       JudithSpritesheet_5: -1154337406
       JudithSpritesheet_6: -1937540174

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/PenguinSpriteSheet-2.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/PenguinSpriteSheet-2.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_0
       rect:
         serializedVersion: 2
-        x: 592
-        y: 15120
-        width: 648
-        height: 600
+        x: 0
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_1
       rect:
         serializedVersion: 2
-        x: 2416
-        y: 15120
-        width: 640
-        height: 600
+        x: 1820
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_2
       rect:
         serializedVersion: 2
-        x: 4232
-        y: 15120
-        width: 648
-        height: 600
+        x: 3640
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_3
       rect:
         serializedVersion: 2
-        x: 6048
-        y: 15128
-        width: 655
-        height: 592
+        x: 5460
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_4
       rect:
         serializedVersion: 2
-        x: 7863
-        y: 15128
-        width: 664
-        height: 592
+        x: 7280
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_5
       rect:
         serializedVersion: 2
-        x: 9679
-        y: 15128
-        width: 672
-        height: 592
+        x: 9100
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_6
       rect:
         serializedVersion: 2
-        x: 11495
-        y: 15120
-        width: 680
-        height: 600
+        x: 10920
+        y: 14564
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_7
       rect:
         serializedVersion: 2
-        x: 560
-        y: 13304
-        width: 704
-        height: 600
+        x: 0
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_8
       rect:
         serializedVersion: 2
-        x: 2376
-        y: 13304
-        width: 712
-        height: 600
+        x: 1820
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_9
       rect:
         serializedVersion: 2
-        x: 4192
-        y: 13296
-        width: 720
-        height: 608
+        x: 3640
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_10
       rect:
         serializedVersion: 2
-        x: 6000
-        y: 13296
-        width: 743
-        height: 616
+        x: 5460
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_11
       rect:
         serializedVersion: 2
-        x: 7823
-        y: 13296
-        width: 744
-        height: 616
+        x: 7280
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_12
       rect:
         serializedVersion: 2
-        x: 9639
-        y: 13296
-        width: 752
-        height: 616
+        x: 9100
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_13
       rect:
         serializedVersion: 2
-        x: 11455
-        y: 13296
-        width: 752
-        height: 616
+        x: 10920
+        y: 12744
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_14
       rect:
         serializedVersion: 2
-        x: 536
-        y: 11472
-        width: 752
-        height: 616
+        x: 0
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_15
       rect:
         serializedVersion: 2
-        x: 2360
-        y: 11472
-        width: 736
-        height: 616
+        x: 1820
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_16
       rect:
         serializedVersion: 2
-        x: 4192
-        y: 11472
-        width: 712
-        height: 616
+        x: 3640
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_17
       rect:
         serializedVersion: 2
-        x: 6032
-        y: 11472
-        width: 687
-        height: 616
+        x: 5460
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_18
       rect:
         serializedVersion: 2
-        x: 7855
-        y: 11472
-        width: 672
-        height: 616
+        x: 7280
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_19
       rect:
         serializedVersion: 2
-        x: 9679
-        y: 11472
-        width: 672
-        height: 608
+        x: 9100
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_20
       rect:
         serializedVersion: 2
-        x: 11471
-        y: 11480
-        width: 744
-        height: 600
+        x: 10920
+        y: 10924
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_21
       rect:
         serializedVersion: 2
-        x: 520
-        y: 9656
-        width: 792
-        height: 600
+        x: 0
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_22
       rect:
         serializedVersion: 2
-        x: 2336
-        y: 9656
-        width: 800
-        height: 600
+        x: 1820
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_23
       rect:
         serializedVersion: 2
-        x: 4176
-        y: 9656
-        width: 768
-        height: 600
+        x: 3640
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_24
       rect:
         serializedVersion: 2
-        x: 6016
-        y: 9656
-        width: 719
-        height: 600
+        x: 5460
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_25
       rect:
         serializedVersion: 2
-        x: 7863
-        y: 9656
-        width: 664
-        height: 592
+        x: 7280
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_26
       rect:
         serializedVersion: 2
-        x: 9679
-        y: 9656
-        width: 664
-        height: 600
+        x: 9100
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_27
       rect:
         serializedVersion: 2
-        x: 11463
-        y: 9656
-        width: 752
-        height: 600
+        x: 10920
+        y: 9104
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_28
       rect:
         serializedVersion: 2
-        x: 528
-        y: 7840
-        width: 784
-        height: 592
+        x: 0
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_29
       rect:
         serializedVersion: 2
-        x: 2360
-        y: 7840
-        width: 752
-        height: 592
+        x: 1820
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_30
       rect:
         serializedVersion: 2
-        x: 4224
-        y: 7840
-        width: 664
-        height: 592
+        x: 3640
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -821,10 +821,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_31
       rect:
         serializedVersion: 2
-        x: 6056
-        y: 7840
-        width: 639
-        height: 592
+        x: 5460
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -843,10 +843,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_32
       rect:
         serializedVersion: 2
-        x: 7871
-        y: 7840
-        width: 648
-        height: 592
+        x: 7280
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -865,10 +865,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_33
       rect:
         serializedVersion: 2
-        x: 9687
-        y: 7840
-        width: 664
-        height: 600
+        x: 9100
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -887,10 +887,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_34
       rect:
         serializedVersion: 2
-        x: 11503
-        y: 7840
-        width: 672
-        height: 600
+        x: 10920
+        y: 7284
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -909,10 +909,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_35
       rect:
         serializedVersion: 2
-        x: 568
-        y: 6024
-        width: 696
-        height: 592
+        x: 0
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -931,10 +931,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_36
       rect:
         serializedVersion: 2
-        x: 2384
-        y: 6016
-        width: 704
-        height: 608
+        x: 1820
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -953,10 +953,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_37
       rect:
         serializedVersion: 2
-        x: 4200
-        y: 6016
-        width: 720
-        height: 608
+        x: 3640
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -975,10 +975,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_38
       rect:
         serializedVersion: 2
-        x: 6016
-        y: 6016
-        width: 727
-        height: 608
+        x: 5460
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -997,10 +997,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_39
       rect:
         serializedVersion: 2
-        x: 7831
-        y: 6016
-        width: 736
-        height: 608
+        x: 7280
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1019,10 +1019,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_40
       rect:
         serializedVersion: 2
-        x: 9647
-        y: 6016
-        width: 744
-        height: 608
+        x: 9100
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1041,10 +1041,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_41
       rect:
         serializedVersion: 2
-        x: 11471
-        y: 6016
-        width: 744
-        height: 608
+        x: 10920
+        y: 5464
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1063,10 +1063,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_42
       rect:
         serializedVersion: 2
-        x: 544
-        y: 4192
-        width: 752
-        height: 616
+        x: 0
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1085,10 +1085,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_43
       rect:
         serializedVersion: 2
-        x: 2368
-        y: 4192
-        width: 744
-        height: 616
+        x: 1820
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1107,10 +1107,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_44
       rect:
         serializedVersion: 2
-        x: 4200
-        y: 4192
-        width: 720
-        height: 616
+        x: 3640
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1129,10 +1129,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_45
       rect:
         serializedVersion: 2
-        x: 6032
-        y: 4192
-        width: 695
-        height: 608
+        x: 5460
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1151,10 +1151,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_46
       rect:
         serializedVersion: 2
-        x: 7863
-        y: 4192
-        width: 672
-        height: 608
+        x: 7280
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1173,10 +1173,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_47
       rect:
         serializedVersion: 2
-        x: 9687
-        y: 4192
-        width: 664
-        height: 608
+        x: 9100
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1195,10 +1195,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_48
       rect:
         serializedVersion: 2
-        x: 11479
-        y: 4192
-        width: 728
-        height: 608
+        x: 10920
+        y: 3644
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1217,10 +1217,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_49
       rect:
         serializedVersion: 2
-        x: 536
-        y: 2376
-        width: 776
-        height: 600
+        x: 0
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1239,10 +1239,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_50
       rect:
         serializedVersion: 2
-        x: 2344
-        y: 2376
-        width: 800
-        height: 600
+        x: 1820
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1261,10 +1261,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_51
       rect:
         serializedVersion: 2
-        x: 4168
-        y: 2376
-        width: 792
-        height: 600
+        x: 3640
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1283,10 +1283,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_52
       rect:
         serializedVersion: 2
-        x: 6000
-        y: 2376
-        width: 767
-        height: 592
+        x: 5460
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1305,10 +1305,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_53
       rect:
         serializedVersion: 2
-        x: 7847
-        y: 2376
-        width: 704
-        height: 592
+        x: 7280
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1327,10 +1327,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_54
       rect:
         serializedVersion: 2
-        x: 9687
-        y: 2376
-        width: 656
-        height: 592
+        x: 9100
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1349,10 +1349,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_55
       rect:
         serializedVersion: 2
-        x: 11479
-        y: 2376
-        width: 720
-        height: 592
+        x: 10920
+        y: 1824
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1371,10 +1371,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_56
       rect:
         serializedVersion: 2
-        x: 528
-        y: 560
-        width: 784
-        height: 592
+        x: 0
+        y: 4
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1393,10 +1393,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_57
       rect:
         serializedVersion: 2
-        x: 2352
-        y: 560
-        width: 768
-        height: 592
+        x: 1820
+        y: 4
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1415,10 +1415,10 @@ TextureImporter:
       name: PenguinSpriteSheet-2_58
       rect:
         serializedVersion: 2
-        x: 4216
-        y: 560
-        width: 680
-        height: 592
+        x: 3640
+        y: 4
+        width: 1820
+        height: 1820
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1447,7 +1447,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":7.0,"y":9.0},"gridSpriteSize":{"x":1820.0,"y":1820.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       PenguinSpriteSheet-2_0: -510152260
       PenguinSpriteSheet-2_1: -403952019

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/cumulus spritesheet.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/cumulus spritesheet.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: cumulus spritesheet_0
       rect:
         serializedVersion: 2
-        x: 340
-        y: 5309
-        width: 429
-        height: 554
+        x: 0
+        y: 5310
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: cumulus spritesheet_1
       rect:
         serializedVersion: 2
-        x: 1388
-        y: 5309
-        width: 430
-        height: 554
+        x: 1048
+        y: 5310
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: cumulus spritesheet_2
       rect:
         serializedVersion: 2
-        x: 2437
-        y: 5309
-        width: 429
-        height: 554
+        x: 2096
+        y: 5310
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: cumulus spritesheet_3
       rect:
         serializedVersion: 2
-        x: 3483
-        y: 5309
-        width: 432
-        height: 554
+        x: 3144
+        y: 5310
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: cumulus spritesheet_4
       rect:
         serializedVersion: 2
-        x: 4531
-        y: 5309
-        width: 432
-        height: 554
+        x: 4192
+        y: 5310
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: cumulus spritesheet_5
       rect:
         serializedVersion: 2
-        x: 340
-        y: 4722
-        width: 429
-        height: 553
+        x: 0
+        y: 4720
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: cumulus spritesheet_6
       rect:
         serializedVersion: 2
-        x: 1386
-        y: 4722
-        width: 432
-        height: 553
+        x: 1048
+        y: 4720
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: cumulus spritesheet_7
       rect:
         serializedVersion: 2
-        x: 2434
-        y: 4722
-        width: 432
-        height: 553
+        x: 2096
+        y: 4720
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: cumulus spritesheet_8
       rect:
         serializedVersion: 2
-        x: 3483
-        y: 4722
-        width: 432
-        height: 553
+        x: 3144
+        y: 4720
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: cumulus spritesheet_9
       rect:
         serializedVersion: 2
-        x: 4528
-        y: 4722
-        width: 435
-        height: 553
+        x: 4192
+        y: 4720
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: cumulus spritesheet_10
       rect:
         serializedVersion: 2
-        x: 337
-        y: 4131
-        width: 435
-        height: 553
+        x: 0
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: cumulus spritesheet_11
       rect:
         serializedVersion: 2
-        x: 1383
-        y: 4131
-        width: 435
-        height: 553
+        x: 1048
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: cumulus spritesheet_12
       rect:
         serializedVersion: 2
-        x: 2431
-        y: 4131
-        width: 435
-        height: 553
+        x: 2096
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: cumulus spritesheet_13
       rect:
         serializedVersion: 2
-        x: 3477
-        y: 4131
-        width: 438
-        height: 553
+        x: 3144
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: cumulus spritesheet_14
       rect:
         serializedVersion: 2
-        x: 4526
-        y: 4131
-        width: 437
-        height: 553
+        x: 4192
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: cumulus spritesheet_15
       rect:
         serializedVersion: 2
-        x: 331
-        y: 3541
-        width: 441
-        height: 553
+        x: 0
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: cumulus spritesheet_16
       rect:
         serializedVersion: 2
-        x: 1380
-        y: 3541
-        width: 441
-        height: 553
+        x: 1048
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: cumulus spritesheet_17
       rect:
         serializedVersion: 2
-        x: 2426
-        y: 3541
-        width: 443
-        height: 556
+        x: 2096
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: cumulus spritesheet_18
       rect:
         serializedVersion: 2
-        x: 3474
-        y: 3541
-        width: 441
-        height: 556
+        x: 3144
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: cumulus spritesheet_19
       rect:
         serializedVersion: 2
-        x: 4520
-        y: 3538
-        width: 443
-        height: 559
+        x: 4192
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: cumulus spritesheet_20
       rect:
         serializedVersion: 2
-        x: 328
+        x: 0
         y: 2950
-        width: 444
-        height: 556
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: cumulus spritesheet_21
       rect:
         serializedVersion: 2
-        x: 1374
+        x: 1048
         y: 2950
-        width: 447
-        height: 556
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: cumulus spritesheet_22
       rect:
         serializedVersion: 2
-        x: 2423
+        x: 2096
         y: 2950
-        width: 446
-        height: 556
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: cumulus spritesheet_23
       rect:
         serializedVersion: 2
-        x: 3468
+        x: 3144
         y: 2950
-        width: 450
-        height: 556
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: cumulus spritesheet_24
       rect:
         serializedVersion: 2
-        x: 4517
-        y: 2947
-        width: 446
-        height: 559
+        x: 4192
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: cumulus spritesheet_25
       rect:
         serializedVersion: 2
-        x: 323
-        y: 2357
-        width: 449
-        height: 558
+        x: 0
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: cumulus spritesheet_26
       rect:
         serializedVersion: 2
-        x: 1371
-        y: 2357
-        width: 450
-        height: 558
+        x: 1048
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: cumulus spritesheet_27
       rect:
         serializedVersion: 2
-        x: 2420
-        y: 2357
-        width: 449
-        height: 558
+        x: 2096
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: cumulus spritesheet_28
       rect:
         serializedVersion: 2
-        x: 3465
-        y: 2357
-        width: 453
-        height: 558
+        x: 3144
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: cumulus spritesheet_29
       rect:
         serializedVersion: 2
-        x: 4514
-        y: 2357
-        width: 452
-        height: 558
+        x: 4192
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: cumulus spritesheet_30
       rect:
         serializedVersion: 2
-        x: 323
-        y: 1769
-        width: 449
-        height: 556
+        x: 0
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -821,10 +821,10 @@ TextureImporter:
       name: cumulus spritesheet_31
       rect:
         serializedVersion: 2
-        x: 1368
-        y: 1769
-        width: 453
-        height: 556
+        x: 1048
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -843,10 +843,10 @@ TextureImporter:
       name: cumulus spritesheet_32
       rect:
         serializedVersion: 2
-        x: 2417
-        y: 1769
-        width: 452
-        height: 556
+        x: 2096
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -865,10 +865,10 @@ TextureImporter:
       name: cumulus spritesheet_33
       rect:
         serializedVersion: 2
-        x: 3465
-        y: 1769
-        width: 453
-        height: 556
+        x: 3144
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -887,10 +887,10 @@ TextureImporter:
       name: cumulus spritesheet_34
       rect:
         serializedVersion: 2
-        x: 4514
-        y: 1769
-        width: 452
-        height: 556
+        x: 4192
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -909,10 +909,10 @@ TextureImporter:
       name: cumulus spritesheet_35
       rect:
         serializedVersion: 2
-        x: 323
-        y: 1178
-        width: 449
-        height: 559
+        x: 0
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -931,10 +931,10 @@ TextureImporter:
       name: cumulus spritesheet_36
       rect:
         serializedVersion: 2
-        x: 1374
-        y: 1178
-        width: 447
-        height: 559
+        x: 1048
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -953,10 +953,10 @@ TextureImporter:
       name: cumulus spritesheet_37
       rect:
         serializedVersion: 2
-        x: 2423
-        y: 1178
-        width: 446
-        height: 559
+        x: 2096
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -975,10 +975,10 @@ TextureImporter:
       name: cumulus spritesheet_38
       rect:
         serializedVersion: 2
-        x: 3474
-        y: 1178
-        width: 441
-        height: 556
+        x: 3144
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -997,10 +997,10 @@ TextureImporter:
       name: cumulus spritesheet_39
       rect:
         serializedVersion: 2
-        x: 4523
-        y: 1178
-        width: 440
-        height: 556
+        x: 4192
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1019,10 +1019,10 @@ TextureImporter:
       name: cumulus spritesheet_40
       rect:
         serializedVersion: 2
-        x: 334
-        y: 591
-        width: 438
-        height: 553
+        x: 0
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1041,10 +1041,10 @@ TextureImporter:
       name: cumulus spritesheet_41
       rect:
         serializedVersion: 2
-        x: 1383
-        y: 591
-        width: 435
-        height: 553
+        x: 1048
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1063,10 +1063,10 @@ TextureImporter:
       name: cumulus spritesheet_42
       rect:
         serializedVersion: 2
-        x: 2431
-        y: 591
-        width: 435
-        height: 553
+        x: 2096
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1085,10 +1085,10 @@ TextureImporter:
       name: cumulus spritesheet_43
       rect:
         serializedVersion: 2
-        x: 3483
-        y: 591
-        width: 432
-        height: 553
+        x: 3144
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1107,10 +1107,10 @@ TextureImporter:
       name: cumulus spritesheet_44
       rect:
         serializedVersion: 2
-        x: 4531
-        y: 591
-        width: 432
-        height: 553
+        x: 4192
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1129,10 +1129,10 @@ TextureImporter:
       name: cumulus spritesheet_45
       rect:
         serializedVersion: 2
-        x: 340
+        x: 0
         y: 0
-        width: 429
-        height: 553
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1151,10 +1151,10 @@ TextureImporter:
       name: cumulus spritesheet_46
       rect:
         serializedVersion: 2
-        x: 1388
+        x: 1048
         y: 0
-        width: 430
-        height: 553
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1183,7 +1183,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":5.0,"y":10.0},"gridSpriteSize":{"x":1048.0,"y":590.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       cumulus spritesheet_0: -320442262
       cumulus spritesheet_1: 1460947913

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/enemy crab.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/enemy crab.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: enemy crab_0
       rect:
         serializedVersion: 2
-        x: 174
-        y: 4201
-        width: 706
-        height: 404
+        x: 0
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: enemy crab_1
       rect:
         serializedVersion: 2
-        x: 1220
-        y: 4203
-        width: 709
-        height: 402
+        x: 1048
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: enemy crab_2
       rect:
         serializedVersion: 2
-        x: 2264
-        y: 4213
-        width: 717
-        height: 392
+        x: 2096
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: enemy crab_3
       rect:
         serializedVersion: 2
-        x: 3306
-        y: 4226
-        width: 726
-        height: 379
+        x: 3144
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: enemy crab_4
       rect:
         serializedVersion: 2
-        x: 4350
-        y: 4224
-        width: 724
-        height: 381
+        x: 4192
+        y: 4130
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: enemy crab_5
       rect:
         serializedVersion: 2
-        x: 154
-        y: 3633
-        width: 711
-        height: 381
+        x: 0
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: enemy crab_6
       rect:
         serializedVersion: 2
-        x: 1203
-        y: 3630
-        width: 675
-        height: 384
+        x: 1048
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: enemy crab_7
       rect:
         serializedVersion: 2
-        x: 2259
-        y: 3630
-        width: 550
-        height: 384
+        x: 2096
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: enemy crab_8
       rect:
         serializedVersion: 2
-        x: 3321
-        y: 3630
-        width: 576
-        height: 384
+        x: 3144
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: enemy crab_9
       rect:
         serializedVersion: 2
-        x: 4385
-        y: 3630
-        width: 528
-        height: 389
+        x: 4192
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: enemy crab_10
       rect:
         serializedVersion: 2
-        x: 212
-        y: 3042
-        width: 502
-        height: 394
+        x: 0
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: enemy crab_11
       rect:
         serializedVersion: 2
-        x: 1279
-        y: 3042
-        width: 484
-        height: 394
+        x: 1048
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: enemy crab_12
       rect:
         serializedVersion: 2
-        x: 2346
-        y: 3042
-        width: 466
-        height: 399
+        x: 2096
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: enemy crab_13
       rect:
         serializedVersion: 2
-        x: 3413
-        y: 3042
-        width: 456
-        height: 404
+        x: 3144
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: enemy crab_14
       rect:
         serializedVersion: 2
-        x: 4521
-        y: 3044
-        width: 404
-        height: 402
+        x: 4192
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: enemy crab_15
       rect:
         serializedVersion: 2
-        x: 299
-        y: 2456
-        width: 438
-        height: 399
+        x: 0
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: enemy crab_16
       rect:
         serializedVersion: 2
-        x: 1356
-        y: 2456
-        width: 435
-        height: 396
+        x: 1048
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: enemy crab_17
       rect:
         serializedVersion: 2
-        x: 2410
-        y: 2456
-        width: 438
-        height: 391
+        x: 2096
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: enemy crab_18
       rect:
         serializedVersion: 2
-        x: 3462
-        y: 2458
-        width: 442
-        height: 382
+        x: 3144
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: enemy crab_19
       rect:
         serializedVersion: 2
-        x: 4513
-        y: 2458
-        width: 451
-        height: 371
+        x: 4192
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: enemy crab_20
       rect:
         serializedVersion: 2
-        x: 322
-        y: 1870
-        width: 463
-        height: 366
+        x: 0
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: enemy crab_21
       rect:
         serializedVersion: 2
-        x: 1371
-        y: 1870
-        width: 476
-        height: 366
+        x: 1048
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: enemy crab_22
       rect:
         serializedVersion: 2
-        x: 2418
-        y: 1870
-        width: 494
-        height: 368
+        x: 2096
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: enemy crab_23
       rect:
         serializedVersion: 2
-        x: 3467
-        y: 1870
-        width: 506
-        height: 374
+        x: 3144
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: enemy crab_24
       rect:
         serializedVersion: 2
-        x: 4518
-        y: 1870
-        width: 520
-        height: 379
+        x: 4192
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: enemy crab_25
       rect:
         serializedVersion: 2
-        x: 330
-        y: 1279
-        width: 527
-        height: 384
+        x: 0
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: enemy crab_26
       rect:
         serializedVersion: 2
-        x: 1379
-        y: 1279
-        width: 537
-        height: 389
+        x: 1048
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: enemy crab_27
       rect:
         serializedVersion: 2
-        x: 2428
-        y: 1277
-        width: 548
-        height: 391
+        x: 2096
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: enemy crab_28
       rect:
         serializedVersion: 2
-        x: 3477
-        y: 1277
-        width: 550
-        height: 394
+        x: 3144
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: enemy crab_29
       rect:
         serializedVersion: 2
-        x: 4516
-        y: 1277
-        width: 563
-        height: 391
+        x: 4192
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: enemy crab_30
       rect:
         serializedVersion: 2
-        x: 310
-        y: 688
-        width: 578
-        height: 381
+        x: 0
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -821,10 +821,10 @@ TextureImporter:
       name: enemy crab_31
       rect:
         serializedVersion: 2
-        x: 1325
-        y: 688
-        width: 609
-        height: 374
+        x: 1048
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -843,10 +843,10 @@ TextureImporter:
       name: enemy crab_32
       rect:
         serializedVersion: 2
-        x: 2333
-        y: 688
-        width: 648
-        height: 374
+        x: 2096
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -865,10 +865,10 @@ TextureImporter:
       name: enemy crab_33
       rect:
         serializedVersion: 2
-        x: 3342
-        y: 688
-        width: 685
-        height: 374
+        x: 3144
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -887,10 +887,10 @@ TextureImporter:
       name: enemy crab_34
       rect:
         serializedVersion: 2
-        x: 4365
-        y: 680
-        width: 709
-        height: 384
+        x: 4192
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -909,10 +909,10 @@ TextureImporter:
       name: enemy crab_35
       rect:
         serializedVersion: 2
-        x: 166
-        y: 84
-        width: 714
-        height: 392
+        x: 0
+        y: 0
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -931,10 +931,10 @@ TextureImporter:
       name: enemy crab_36
       rect:
         serializedVersion: 2
-        x: 1220
-        y: 79
-        width: 707
-        height: 397
+        x: 1048
+        y: 0
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -963,7 +963,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":5.0,"y":8.0},"gridSpriteSize":{"x":1048.0,"y":590.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       enemy crab_0: 638894422
       enemy crab_1: -1213837276

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/julien spritesheet.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/julien spritesheet.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: julien spritesheet_0
       rect:
         serializedVersion: 2
-        x: 318
-        y: 8666
-        width: 1201
-        height: 950
+        x: 0
+        y: 8640
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: julien spritesheet_1
       rect:
         serializedVersion: 2
-        x: 2235
-        y: 8666
-        width: 1201
-        height: 950
+        x: 1920
+        y: 8640
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: julien spritesheet_2
       rect:
         serializedVersion: 2
-        x: 4157
-        y: 8666
-        width: 1201
-        height: 959
+        x: 3840
+        y: 8640
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: julien spritesheet_3
       rect:
         serializedVersion: 2
-        x: 6079
-        y: 8666
-        width: 1200
-        height: 969
+        x: 5760
+        y: 8640
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: julien spritesheet_4
       rect:
         serializedVersion: 2
-        x: 7996
-        y: 8666
-        width: 1205
-        height: 983
+        x: 7680
+        y: 8640
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: julien spritesheet_5
       rect:
         serializedVersion: 2
-        x: 323
-        y: 7584
-        width: 1196
-        height: 997
+        x: 0
+        y: 7560
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: julien spritesheet_6
       rect:
         serializedVersion: 2
-        x: 2245
-        y: 7584
-        width: 1195
-        height: 1011
+        x: 1920
+        y: 7560
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: julien spritesheet_7
       rect:
         serializedVersion: 2
-        x: 4171
-        y: 7584
-        width: 1187
-        height: 1025
+        x: 3840
+        y: 7560
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: julien spritesheet_8
       rect:
         serializedVersion: 2
-        x: 6098
-        y: 7580
-        width: 1177
-        height: 1039
+        x: 5760
+        y: 7560
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: julien spritesheet_9
       rect:
         serializedVersion: 2
-        x: 8025
-        y: 7580
-        width: 1162
-        height: 1048
+        x: 7680
+        y: 7560
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: julien spritesheet_10
       rect:
         serializedVersion: 2
-        x: 356
-        y: 6497
-        width: 1148
-        height: 1054
+        x: 0
+        y: 6480
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: julien spritesheet_11
       rect:
         serializedVersion: 2
-        x: 2283
-        y: 6497
-        width: 1138
-        height: 1054
+        x: 1920
+        y: 6480
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: julien spritesheet_12
       rect:
         serializedVersion: 2
-        x: 4209
-        y: 6497
-        width: 1130
-        height: 1054
+        x: 3840
+        y: 6480
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: julien spritesheet_13
       rect:
         serializedVersion: 2
-        x: 6131
-        y: 6497
-        width: 1125
-        height: 1054
+        x: 5760
+        y: 6480
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: julien spritesheet_14
       rect:
         serializedVersion: 2
-        x: 8058
-        y: 6497
-        width: 1115
-        height: 1054
+        x: 7680
+        y: 6480
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: julien spritesheet_15
       rect:
         serializedVersion: 2
-        x: 375
-        y: 5415
-        width: 1120
-        height: 1054
+        x: 0
+        y: 5400
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: julien spritesheet_16
       rect:
         serializedVersion: 2
-        x: 2292
-        y: 5415
-        width: 1125
-        height: 1044
+        x: 1920
+        y: 5400
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: julien spritesheet_17
       rect:
         serializedVersion: 2
-        x: 4204
-        y: 5415
-        width: 1135
-        height: 1035
+        x: 3840
+        y: 5400
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: julien spritesheet_18
       rect:
         serializedVersion: 2
-        x: 6117
-        y: 5415
-        width: 1144
-        height: 1016
+        x: 5760
+        y: 5400
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: julien spritesheet_19
       rect:
         serializedVersion: 2
-        x: 8029
-        y: 5415
-        width: 1153
-        height: 997
+        x: 7680
+        y: 5400
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: julien spritesheet_20
       rect:
         serializedVersion: 2
-        x: 342
-        y: 4338
-        width: 1162
-        height: 978
+        x: 0
+        y: 4320
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: julien spritesheet_21
       rect:
         serializedVersion: 2
-        x: 2249
-        y: 4338
-        width: 1182
-        height: 968
+        x: 1920
+        y: 4320
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: julien spritesheet_22
       rect:
         serializedVersion: 2
-        x: 4152
-        y: 4343
-        width: 1210
-        height: 949
+        x: 3840
+        y: 4320
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: julien spritesheet_23
       rect:
         serializedVersion: 2
-        x: 6065
-        y: 4343
-        width: 1238
-        height: 935
+        x: 5760
+        y: 4320
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: julien spritesheet_24
       rect:
         serializedVersion: 2
-        x: 7982
-        y: 4343
-        width: 1262
-        height: 930
+        x: 7680
+        y: 4320
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: julien spritesheet_25
       rect:
         serializedVersion: 2
-        x: 299
-        y: 3265
-        width: 1262
-        height: 940
+        x: 0
+        y: 3240
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: julien spritesheet_26
       rect:
         serializedVersion: 2
-        x: 2216
-        y: 3265
-        width: 1258
-        height: 954
+        x: 1920
+        y: 3240
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: julien spritesheet_27
       rect:
         serializedVersion: 2
-        x: 4133
-        y: 3265
-        width: 1258
-        height: 978
+        x: 3840
+        y: 3240
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: julien spritesheet_28
       rect:
         serializedVersion: 2
-        x: 6055
-        y: 3265
-        width: 1258
-        height: 1002
+        x: 5760
+        y: 3240
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: julien spritesheet_29
       rect:
         serializedVersion: 2
-        x: 7977
-        y: 3261
-        width: 1253
-        height: 1025
+        x: 7680
+        y: 3240
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: julien spritesheet_30
       rect:
         serializedVersion: 2
-        x: 299
-        y: 2183
-        width: 1248
-        height: 1040
+        x: 0
+        y: 2160
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -821,10 +821,10 @@ TextureImporter:
       name: julien spritesheet_31
       rect:
         serializedVersion: 2
-        x: 2226
-        y: 2178
-        width: 1233
-        height: 1059
+        x: 1920
+        y: 2160
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -843,10 +843,10 @@ TextureImporter:
       name: julien spritesheet_32
       rect:
         serializedVersion: 2
-        x: 4152
-        y: 2178
-        width: 1220
-        height: 1064
+        x: 3840
+        y: 2160
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -865,10 +865,10 @@ TextureImporter:
       name: julien spritesheet_33
       rect:
         serializedVersion: 2
-        x: 6079
-        y: 2178
-        width: 1210
-        height: 1064
+        x: 5760
+        y: 2160
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -887,10 +887,10 @@ TextureImporter:
       name: julien spritesheet_34
       rect:
         serializedVersion: 2
-        x: 8001
-        y: 2174
-        width: 1205
-        height: 1068
+        x: 7680
+        y: 2160
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -909,10 +909,10 @@ TextureImporter:
       name: julien spritesheet_35
       rect:
         serializedVersion: 2
-        x: 327
-        y: 1096
-        width: 1196
-        height: 1063
+        x: 0
+        y: 1080
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -931,10 +931,10 @@ TextureImporter:
       name: julien spritesheet_36
       rect:
         serializedVersion: 2
-        x: 2249
-        y: 1096
-        width: 1191
-        height: 1059
+        x: 1920
+        y: 1080
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -953,10 +953,10 @@ TextureImporter:
       name: julien spritesheet_37
       rect:
         serializedVersion: 2
-        x: 4166
-        y: 1096
-        width: 1196
-        height: 1049
+        x: 3840
+        y: 1080
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -975,10 +975,10 @@ TextureImporter:
       name: julien spritesheet_38
       rect:
         serializedVersion: 2
-        x: 6088
-        y: 1096
-        width: 1191
-        height: 1044
+        x: 5760
+        y: 1080
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -997,10 +997,10 @@ TextureImporter:
       name: julien spritesheet_39
       rect:
         serializedVersion: 2
-        x: 8001
-        y: 1096
-        width: 1200
-        height: 1040
+        x: 7680
+        y: 1080
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1019,10 +1019,10 @@ TextureImporter:
       name: julien spritesheet_40
       rect:
         serializedVersion: 2
-        x: 318
-        y: 19
-        width: 1205
-        height: 1020
+        x: 0
+        y: 0
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1041,10 +1041,10 @@ TextureImporter:
       name: julien spritesheet_41
       rect:
         serializedVersion: 2
-        x: 2235
-        y: 19
-        width: 1210
-        height: 1006
+        x: 1920
+        y: 0
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1063,10 +1063,10 @@ TextureImporter:
       name: julien spritesheet_42
       rect:
         serializedVersion: 2
-        x: 4157
-        y: 19
-        width: 1205
-        height: 992
+        x: 3840
+        y: 0
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1085,10 +1085,10 @@ TextureImporter:
       name: julien spritesheet_43
       rect:
         serializedVersion: 2
-        x: 6074
-        y: 24
-        width: 1205
-        height: 973
+        x: 5760
+        y: 0
+        width: 1920
+        height: 1080
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -1117,7 +1117,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":5.0,"y":9.0},"gridSpriteSize":{"x":1920.0,"y":1080.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       julien spritesheet_0: -390816793
       julien spritesheet_1: 1527350155

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/mort spritesheet.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/mort spritesheet.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: mort spritesheet_0
       rect:
         serializedVersion: 2
-        x: 420
-        y: 6939
-        width: 585
-        height: 493
+        x: 0
+        y: 6708
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: mort spritesheet_1
       rect:
         serializedVersion: 2
-        x: 1911
-        y: 6939
-        width: 584
-        height: 493
+        x: 1491
+        y: 6708
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: mort spritesheet_2
       rect:
         serializedVersion: 2
-        x: 3397
-        y: 6939
-        width: 592
-        height: 497
+        x: 2982
+        y: 6708
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: mort spritesheet_3
       rect:
         serializedVersion: 2
-        x: 4883
-        y: 6936
-        width: 604
-        height: 504
+        x: 4473
+        y: 6708
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: mort spritesheet_4
       rect:
         serializedVersion: 2
-        x: 6370
-        y: 6936
-        width: 615
-        height: 512
+        x: 5964
+        y: 6708
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: mort spritesheet_5
       rect:
         serializedVersion: 2
-        x: 397
-        y: 5816
-        width: 631
-        height: 520
+        x: 0
+        y: 5590
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: mort spritesheet_6
       rect:
         serializedVersion: 2
-        x: 1880
-        y: 5812
-        width: 646
-        height: 531
+        x: 1491
+        y: 5590
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: mort spritesheet_7
       rect:
         serializedVersion: 2
-        x: 3366
-        y: 5808
-        width: 658
-        height: 539
+        x: 2982
+        y: 5590
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: mort spritesheet_8
       rect:
         serializedVersion: 2
-        x: 4853
-        y: 5808
-        width: 665
-        height: 547
+        x: 4473
+        y: 5590
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: mort spritesheet_9
       rect:
         serializedVersion: 2
-        x: 6339
-        y: 5805
-        width: 673
-        height: 554
+        x: 5964
+        y: 5590
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: mort spritesheet_10
       rect:
         serializedVersion: 2
-        x: 374
-        y: 4689
-        width: 673
-        height: 554
+        x: 0
+        y: 4472
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: mort spritesheet_11
       rect:
         serializedVersion: 2
-        x: 1865
-        y: 4689
-        width: 676
-        height: 554
+        x: 1491
+        y: 4472
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: mort spritesheet_12
       rect:
         serializedVersion: 2
-        x: 3363
-        y: 4693
-        width: 661
-        height: 542
+        x: 2982
+        y: 4472
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: mort spritesheet_13
       rect:
         serializedVersion: 2
-        x: 4860
-        y: 4693
-        width: 650
-        height: 535
+        x: 4473
+        y: 4472
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: mort spritesheet_14
       rect:
         serializedVersion: 2
-        x: 6366
-        y: 4696
-        width: 623
-        height: 516
+        x: 5964
+        y: 4472
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: mort spritesheet_15
       rect:
         serializedVersion: 2
-        x: 413
-        y: 3584
-        width: 600
-        height: 501
+        x: 0
+        y: 3354
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: mort spritesheet_16
       rect:
         serializedVersion: 2
-        x: 1911
-        y: 3584
-        width: 584
-        height: 493
+        x: 1491
+        y: 3354
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: mort spritesheet_17
       rect:
         serializedVersion: 2
-        x: 3397
-        y: 3584
-        width: 592
-        height: 493
+        x: 2982
+        y: 3354
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: mort spritesheet_18
       rect:
         serializedVersion: 2
-        x: 4883
-        y: 3581
-        width: 604
-        height: 496
+        x: 4473
+        y: 3354
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: mort spritesheet_19
       rect:
         serializedVersion: 2
-        x: 6366
-        y: 3581
-        width: 623
-        height: 496
+        x: 5964
+        y: 3354
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: mort spritesheet_20
       rect:
         serializedVersion: 2
-        x: 394
-        y: 2461
-        width: 638
-        height: 500
+        x: 0
+        y: 2236
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: mort spritesheet_21
       rect:
         serializedVersion: 2
-        x: 1876
-        y: 2457
-        width: 654
-        height: 504
+        x: 1491
+        y: 2236
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: mort spritesheet_22
       rect:
         serializedVersion: 2
-        x: 3363
-        y: 2453
-        width: 664
-        height: 505
+        x: 2982
+        y: 2236
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: mort spritesheet_23
       rect:
         serializedVersion: 2
-        x: 4849
-        y: 2453
-        width: 673
-        height: 505
+        x: 4473
+        y: 2236
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: mort spritesheet_24
       rect:
         serializedVersion: 2
-        x: 6339
-        y: 2449
-        width: 673
-        height: 509
+        x: 5964
+        y: 2236
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: mort spritesheet_25
       rect:
         serializedVersion: 2
-        x: 378
-        y: 1334
-        width: 669
-        height: 508
+        x: 0
+        y: 1118
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: mort spritesheet_26
       rect:
         serializedVersion: 2
-        x: 1872
-        y: 1337
-        width: 665
-        height: 505
+        x: 1491
+        y: 1118
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: mort spritesheet_27
       rect:
         serializedVersion: 2
-        x: 3370
-        y: 1341
-        width: 650
-        height: 501
+        x: 2982
+        y: 1118
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: mort spritesheet_28
       rect:
         serializedVersion: 2
-        x: 4872
-        y: 1341
-        width: 627
-        height: 501
+        x: 4473
+        y: 1118
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: mort spritesheet_29
       rect:
         serializedVersion: 2
-        x: 6374
-        y: 1345
-        width: 603
-        height: 497
+        x: 5964
+        y: 1118
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: mort spritesheet_30
       rect:
         serializedVersion: 2
-        x: 417
-        y: 229
-        width: 588
-        height: 497
+        x: 0
+        y: 0
+        width: 1491
+        height: 1118
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -831,7 +831,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":5.0,"y":7.0},"gridSpriteSize":{"x":1491.0,"y":1118.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       mort spritesheet_0: -753580909
       mort spritesheet_1: -1929246777

--- a/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/reg crab.png.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Spritesheets/reg crab.png.meta
@@ -139,10 +139,10 @@ TextureImporter:
       name: reg crab_0
       rect:
         serializedVersion: 2
-        x: 171
-        y: 3636
-        width: 655
-        height: 415
+        x: 0
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -161,10 +161,10 @@ TextureImporter:
       name: reg crab_1
       rect:
         serializedVersion: 2
-        x: 1218
-        y: 3639
-        width: 657
-        height: 409
+        x: 1048
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -183,10 +183,10 @@ TextureImporter:
       name: reg crab_2
       rect:
         serializedVersion: 2
-        x: 2269
-        y: 3641
-        width: 658
-        height: 405
+        x: 2096
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -205,10 +205,10 @@ TextureImporter:
       name: reg crab_3
       rect:
         serializedVersion: 2
-        x: 3321
-        y: 3644
-        width: 655
-        height: 396
+        x: 3144
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -227,10 +227,10 @@ TextureImporter:
       name: reg crab_4
       rect:
         serializedVersion: 2
-        x: 4370
-        y: 3649
-        width: 660
-        height: 384
+        x: 4192
+        y: 3540
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -249,10 +249,10 @@ TextureImporter:
       name: reg crab_5
       rect:
         serializedVersion: 2
-        x: 184
-        y: 3063
-        width: 658
-        height: 371
+        x: 0
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -271,10 +271,10 @@ TextureImporter:
       name: reg crab_6
       rect:
         serializedVersion: 2
-        x: 1236
-        y: 3066
-        width: 662
-        height: 358
+        x: 1048
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -293,10 +293,10 @@ TextureImporter:
       name: reg crab_7
       rect:
         serializedVersion: 2
-        x: 2293
-        y: 3071
-        width: 660
-        height: 343
+        x: 2096
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -315,10 +315,10 @@ TextureImporter:
       name: reg crab_8
       rect:
         serializedVersion: 2
-        x: 3347
-        y: 3071
-        width: 662
-        height: 332
+        x: 3144
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -337,10 +337,10 @@ TextureImporter:
       name: reg crab_9
       rect:
         serializedVersion: 2
-        x: 4406
-        y: 3066
-        width: 663
-        height: 337
+        x: 4192
+        y: 2950
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -359,10 +359,10 @@ TextureImporter:
       name: reg crab_10
       rect:
         serializedVersion: 2
-        x: 225
-        y: 2467
-        width: 663
-        height: 363
+        x: 0
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -381,10 +381,10 @@ TextureImporter:
       name: reg crab_11
       rect:
         serializedVersion: 2
-        x: 1284
-        y: 2462
-        width: 661
-        height: 381
+        x: 1048
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -403,10 +403,10 @@ TextureImporter:
       name: reg crab_12
       rect:
         serializedVersion: 2
-        x: 2344
-        y: 2462
-        width: 657
-        height: 386
+        x: 2096
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -425,10 +425,10 @@ TextureImporter:
       name: reg crab_13
       rect:
         serializedVersion: 2
-        x: 3398
-        y: 2467
-        width: 652
-        height: 384
+        x: 3144
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -447,10 +447,10 @@ TextureImporter:
       name: reg crab_14
       rect:
         serializedVersion: 2
-        x: 4447
-        y: 2472
-        width: 652
-        height: 379
+        x: 4192
+        y: 2360
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -469,10 +469,10 @@ TextureImporter:
       name: reg crab_15
       rect:
         serializedVersion: 2
-        x: 256
-        y: 1881
-        width: 650
-        height: 378
+        x: 0
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -491,10 +491,10 @@ TextureImporter:
       name: reg crab_16
       rect:
         serializedVersion: 2
-        x: 1300
-        y: 1881
-        width: 650
-        height: 373
+        x: 1048
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -513,10 +513,10 @@ TextureImporter:
       name: reg crab_17
       rect:
         serializedVersion: 2
-        x: 2346
-        y: 1878
-        width: 648
-        height: 369
+        x: 2096
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -535,10 +535,10 @@ TextureImporter:
       name: reg crab_18
       rect:
         serializedVersion: 2
-        x: 3390
-        y: 1878
-        width: 647
-        height: 361
+        x: 3144
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -557,10 +557,10 @@ TextureImporter:
       name: reg crab_19
       rect:
         serializedVersion: 2
-        x: 4434
-        y: 1881
-        width: 647
-        height: 350
+        x: 4192
+        y: 1770
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -579,10 +579,10 @@ TextureImporter:
       name: reg crab_20
       rect:
         serializedVersion: 2
-        x: 238
-        y: 1292
-        width: 645
-        height: 343
+        x: 0
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -601,10 +601,10 @@ TextureImporter:
       name: reg crab_21
       rect:
         serializedVersion: 2
-        x: 1279
-        y: 1295
-        width: 648
-        height: 332
+        x: 1048
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -623,10 +623,10 @@ TextureImporter:
       name: reg crab_22
       rect:
         serializedVersion: 2
-        x: 2321
-        y: 1295
-        width: 647
-        height: 343
+        x: 2096
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -645,10 +645,10 @@ TextureImporter:
       name: reg crab_23
       rect:
         serializedVersion: 2
-        x: 3359
-        y: 1292
-        width: 650
-        height: 358
+        x: 3144
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -667,10 +667,10 @@ TextureImporter:
       name: reg crab_24
       rect:
         serializedVersion: 2
-        x: 4398
-        y: 1290
-        width: 655
-        height: 371
+        x: 4192
+        y: 1180
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -689,10 +689,10 @@ TextureImporter:
       name: reg crab_25
       rect:
         serializedVersion: 2
-        x: 194
-        y: 693
-        width: 661
-        height: 384
+        x: 0
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -711,10 +711,10 @@ TextureImporter:
       name: reg crab_26
       rect:
         serializedVersion: 2
-        x: 1233
-        y: 688
-        width: 663
-        height: 400
+        x: 1048
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -733,10 +733,10 @@ TextureImporter:
       name: reg crab_27
       rect:
         serializedVersion: 2
-        x: 2275
-        y: 686
-        width: 662
-        height: 407
+        x: 2096
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -755,10 +755,10 @@ TextureImporter:
       name: reg crab_28
       rect:
         serializedVersion: 2
-        x: 3316
-        y: 686
-        width: 663
-        height: 409
+        x: 3144
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -777,10 +777,10 @@ TextureImporter:
       name: reg crab_29
       rect:
         serializedVersion: 2
-        x: 4362
-        y: 683
-        width: 661
-        height: 415
+        x: 4192
+        y: 590
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -799,10 +799,10 @@ TextureImporter:
       name: reg crab_30
       rect:
         serializedVersion: 2
-        x: 171
-        y: 97
-        width: 655
-        height: 412
+        x: 0
+        y: 0
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -821,10 +821,10 @@ TextureImporter:
       name: reg crab_31
       rect:
         serializedVersion: 2
-        x: 1218
-        y: 97
-        width: 655
-        height: 412
+        x: 1048
+        y: 0
+        width: 1048
+        height: 590
       alignment: 0
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
@@ -853,7 +853,7 @@ TextureImporter:
     spriteCustomMetadata:
       entries:
       - key: SpriteEditor.SliceSettings
-        value: '{"sliceOnImport":false,"gridCellCount":{"x":1.0,"y":1.0},"gridSpriteSize":{"x":64.0,"y":64.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":0,"keepEmptyRects":false,"isAlternate":false}'
+        value: '{"sliceOnImport":false,"gridCellCount":{"x":5.0,"y":7.0},"gridSpriteSize":{"x":1048.0,"y":590.0},"gridSpriteOffset":{"x":0.0,"y":0.0},"gridSpritePadding":{"x":0.0,"y":0.0},"pivot":{"x":0.5,"y":0.5},"pivotPixels":{"x":0.0,"y":0.0},"autoSlicingMethod":0,"spriteAlignment":0,"pivotUnitMode":0,"slicingType":2,"keepEmptyRects":false,"isAlternate":false}'
     nameFileIdTable:
       reg crab_0: -856124683
       reg crab_1: -1051529512

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -28430,10 +28430,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6e53348d34ea4e4199e12cc1fbf7269, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DynamicTileTexturing
-  tileRenderer: {fileID: 0}
-  tile: {fileID: 0}
   normalTexture: {fileID: 2100000, guid: e1e9fbe58415931448eb637058308e9e, type: 2}
-  iceTexture: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
 --- !u!114 &1351079586
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32962,6 +32959,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: -1.9584961
       objectReference: {fileID: 0}
+    - target: {fileID: 5813188273321872142, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -12.999939
+      objectReference: {fileID: 0}
     - target: {fileID: 6019136434661588726, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 8.640686
@@ -32984,7 +32985,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7804412830963627737, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -13
+      value: -12.999939
       objectReference: {fileID: 0}
     - target: {fileID: 7830017286838153912, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_text
@@ -34316,10 +34317,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6e53348d34ea4e4199e12cc1fbf7269, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DynamicTileTexturing
-  tileRenderer: {fileID: 0}
-  tile: {fileID: 0}
   normalTexture: {fileID: 2100000, guid: e1e9fbe58415931448eb637058308e9e, type: 2}
-  iceTexture: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
 --- !u!114 &1739471987
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -35173,10 +35171,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6e53348d34ea4e4199e12cc1fbf7269, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DynamicTileTexturing
-  tileRenderer: {fileID: 0}
-  tile: {fileID: 0}
   normalTexture: {fileID: 2100000, guid: e1e9fbe58415931448eb637058308e9e, type: 2}
-  iceTexture: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
 --- !u!114 &1837369717
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -43060,10 +43055,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6e53348d34ea4e4199e12cc1fbf7269, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DynamicTileTexturing
-  tileRenderer: {fileID: 0}
-  tile: {fileID: 0}
   normalTexture: {fileID: 2100000, guid: e1e9fbe58415931448eb637058308e9e, type: 2}
-  iceTexture: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
 --- !u!114 &2129601380
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -43777,10 +43769,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c6e53348d34ea4e4199e12cc1fbf7269, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DynamicTileTexturing
-  tileRenderer: {fileID: 0}
-  tile: {fileID: 0}
   normalTexture: {fileID: 2100000, guid: e1e9fbe58415931448eb637058308e9e, type: 2}
-  iceTexture: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
 --- !u!114 &2141377682
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Untitled-26.slnx
+++ b/00 Unity Proj/Untitled-26/Untitled-26.slnx
@@ -1,0 +1,12 @@
+﻿<Solution>
+  <Project Path="Unity.InputSystem.csproj" />
+  <Project Path="Assembly-CSharp.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.UnityLocalization.Editor.csproj" />
+  <Project Path="Unity.InputSystem.ForUI.csproj" />
+  <Project Path="Unity.InputSystem.TestFramework.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.Unity.Addressables.csproj" />
+  <Project Path="Unity.InputSystem.DocCodeSamples.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.UnityMathematics.csproj" />
+  <Project Path="Sirenix.OdinInspector.Modules.UnityLocalization.csproj" />
+  <Project Path="Unity.InputSystem.IntegrationTests.csproj" />
+</Solution>


### PR DESCRIPTION
### Oasis
- Removed "ghost boxes" from Skye and plants on oasis (toggled preserve specular lighting)
- Fixed the jittering that was present on the NPCs (expanded the sprites on the sprite sheets)