### PR TITLE
Hotfix | Updated GameManager Persistence to Resolve Airship Bug

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameManager.cs
@@ -1,9 +1,9 @@
 using UnityCommunity.UnitySingleton;
 using UnityEngine.SceneManagement;
 
-// This is the GameManager. It is a singleton that will persist across scenes.
+// This is the GameManager. It is a singleton that is primarily used for handling scene changes.
 
-public class GameManager : PersistentMonoSingleton<GameManager>
+public class GameManager : MonoSingleton<GameManager>
 {
     public enum SceneDestination
     {
@@ -16,7 +16,7 @@ public class GameManager : PersistentMonoSingleton<GameManager>
     }
     
     // Placeholder string
-    private string scene = "scene name";
+    private string scene;
 
     /// <summary>
     /// Called by SceneChanger.cs to prep the next scene to load. Once the
@@ -40,20 +40,16 @@ public class GameManager : PersistentMonoSingleton<GameManager>
         switch (destination)
         {
             case SceneDestination.MainMenu:
-                scene = "MainMenu";
-                break;
+                return "MainMenu";
             case SceneDestination.MotherIsland:
-                scene = "Mother_Island";
-                break;
+                return "Mother_Island";
             case SceneDestination.IceIsland:
-                scene = "Ice_Island";
-                break;
+                return "Ice_Island";
             case SceneDestination.OasisIsland:
-                scene = "Oasis_Island";
-                break;
+                return "Oasis_Island";
+            default:
+                return "MainMenu";
         }
-        
-        return scene;
     }
     
     /// <summary>

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
@@ -277,6 +277,7 @@ public class ViewManager : MonoBehaviour
     private void OnLoadingVideoFinished(VideoPlayer vp)
     {
         loadingVideoPlayer.Stop();
+        loadingVideoPlayer.time = 0;
         loadingComplete?.Invoke();
     }
 }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`hotfix/double-check-airship-transitions`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/double-check-airship-transitions) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR introduces a hotfix that is posthumously related to #413.

### In-depth Details
- The airship traversal animation was fully established for all scenes in [#514](https://github.com/Precipice-Games/untitled-26/pull/514).
- However, @cassdaw realized that the transition was performing only once, and all other scene loads after that just didn't work.
- The only method that seemed to work was changing the GameManager to be non-persistent across scenes.
     - It was previously a PersistentMonoSingleton<>; now uses the MonoSingleton<> wrapper.
- It probably has something to do with the scene string was assigned.
- Regardless, this is working for now and we can always revisit it if we really need the GameManager to be persistent.