### PR TITLE
Related to #467 | Disabled Input Visualizer UI

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -35026,67 +35026,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8014860526984270938, guid: 52fcc2c214e11dd46bc310e39123907a, type: 3}
   m_PrefabInstance: {fileID: 1591255923}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1594694668
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1309930466712146503, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_Name
-      value: SimpleControlsVis
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146503, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.46587
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -2.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 3.37672
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
 --- !u!1001 &1599294966
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -50838,6 +50777,67 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!1001 &2095135721
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1309930466712146503, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_Name
+      value: SimpleControlsVis
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146503, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 14.03491
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.81891
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
 --- !u!1001 &2099492924
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -55482,4 +55482,4 @@ SceneRoots:
   - {fileID: 4948310389671487639}
   - {fileID: 1422275508}
   - {fileID: 4029354900766978087}
-  - {fileID: 1594694668}
+  - {fileID: 2095135721}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
@@ -1291,6 +1291,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: SimpleControlsVis
       objectReference: {fileID: 0}
+    - target: {fileID: 1309930466712146503, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1309930466712146553, guid: d47a6d369eb262d4c9ace8bac037f99d, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.19094

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Misc/DevBuildGameObject.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Misc/DevBuildGameObject.cs
@@ -4,6 +4,11 @@ public class DevBuildGameObject : MonoBehaviour
 {
     private void Awake()
     {
+        if (Debug.isDebugBuild)
+        {
+            Debug.Log($"Debug.isDebugBuild >> {Debug.isDebugBuild}");
+        }
+        
         gameObject.SetActive(Debug.isDebugBuild);
     }
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Misc/SimpleControlsVis.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Misc/SimpleControlsVis.prefab
@@ -124,6 +124,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1309930466712146553}
   - component: {fileID: 1309930466712146552}
+  - component: {fileID: 3478242273297894708}
   m_Layer: 0
   m_Name: SimpleControlsVis
   m_TagString: Untagged
@@ -175,6 +176,18 @@ MonoBehaviour:
   m_ActionReference: {fileID: -4265220639702670642, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
   m_ActionName: 
   m_ShowControlName: 1
+--- !u!114 &3478242273297894708
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1309930466712146503}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 93ec69727bee89540bb23322384fe69b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DevBuildGameObject
 --- !u!1 &1309930467610566049
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/467-pre-alpha-character-controller-physics`](https://github.com/Precipice-Games/untitled-26/tree/issue/467-pre-alpha-character-controller-physics) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR is related to #467.

### In-depth Details
- As apart of [#467](https://github.com/Precipice-Games/untitled-26/issues/467), I had been working with a custom input controls visualizer.
     - I made a copy of the sample prefab Unity provided for its Input System package.
- I just temporarily disabled the prefab in every scene that it's in.
- It's a tool that should only be used in the editor and not be visually present for builds.