### PR TITLE
Related to #383 | Reworked Event Handling for Puzzle Feedback

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
@@ -3411,6 +3411,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c25cdba096906e54bb7d84f6b69f698b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: '::'
+  noCardUsagesLeft:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2186891206686781560}
+        m_TargetAssemblyTypeName: PuzzleFeedback, Assembly-CSharp
+        m_MethodName: NoMoreCardUses
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   startingMana: 3
   moveLeftUses: 2
   moveRightUses: 2

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -43386,7 +43386,7 @@ GameObject:
   - component: {fileID: 1837369719}
   - component: {fileID: 1837369718}
   - component: {fileID: 1837369717}
-  - component: {fileID: 1837369716}
+  - component: {fileID: 1837369722}
   m_Layer: 0
   m_Name: DriftIsland (17)
   m_TagString: Untagged
@@ -43409,19 +43409,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 8739545680216347641}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1837369716
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1837369714}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c6e53348d34ea4e4199e12cc1fbf7269, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::DynamicTileTexturing
-  normalTexture: {fileID: 2100000, guid: 9cb797cb0cd8711468d8d26ab44ffa86, type: 2}
 --- !u!114 &1837369717
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -43546,6 +43533,20 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1837369714}
   m_Mesh: {fileID: -6209912238109660980, guid: 37d21edc3a321fe4fad3e34a472efe1d, type: 3}
+--- !u!114 &1837369722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1837369714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b14d420945b46a7912d6e122fbdd172, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::IceTexturing
+  normalTexture: {fileID: 2100000, guid: e1e9fbe58415931448eb637058308e9e, type: 2}
+  iceTexture: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
 --- !u!1 &1844928698
 GameObject:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs
@@ -22,7 +22,7 @@ public class PuzzleFeedback : MonoBehaviour
 
     private bool isFlashing = false;
     
-    private PuzzleInformation puzzleInfo;
+    private PuzzleInformation thisPuzzle;
     
     // Intervals used to determine when to flash the tile's color during the timer
     // Flash intervals
@@ -42,7 +42,7 @@ public class PuzzleFeedback : MonoBehaviour
         messageText = feedbackText.GetComponent<TMP_Text>();
         
         // Identify what puzzle this script belongs to
-        puzzleInfo = GetComponentInParent<PuzzleInformation>();
+        thisPuzzle = GetComponentInParent<PuzzleInformation>();
         
         // Hide popup text at start
         feedbackText.SetActive(false);
@@ -53,7 +53,6 @@ public class PuzzleFeedback : MonoBehaviour
     {
         SelectableTile.cellOccupied += CellIsOccupied;
         SelectableTile.moveOutOfBounds += MoveIsOutOfBounds;
-        ResourceManager.noCardUsagesLeft += NoMoreCardUses;
     }
     
     // Unsubscribe from events
@@ -63,23 +62,31 @@ public class PuzzleFeedback : MonoBehaviour
         SelectableTile.moveOutOfBounds -= MoveIsOutOfBounds;
     }
 
-    private void CellIsOccupied(SelectableTile selectableTile)
+    private void CellIsOccupied(PuzzleInformation puzzleInfo, SelectableTile selectableTile)
     {
-        StartFeedback(selectableTile, "That space is occupied!");
+        if (puzzleInfo == thisPuzzle)
+        {
+            StartFeedback(selectableTile, "That space is occupied!");
+        }
     }
     
-    private void MoveIsOutOfBounds(SelectableTile selectableTile)
+    private void MoveIsOutOfBounds(PuzzleInformation puzzleInfo, SelectableTile selectableTile)
     {
-        StartFeedback(selectableTile, "You cannot move outside the grid!");
+        if (puzzleInfo == thisPuzzle)
+        {
+            StartFeedback(selectableTile, "You cannot move outside the grid!");
+        }
     }
 
     /// <summary>
     /// NEW: Triggered when player has no more card usages left
     /// </summary>
-    private void NoMoreCardUses(PuzzleInformation puzzleInfo, string message)
+    public void NoMoreCardUses(PuzzleInformation puzzleInfo, string message)
     {
-        if ()
-        StartFeedback(null, "No more card usages!");
+        if (puzzleInfo == thisPuzzle)
+        {
+            StartFeedback(null, "No more card usages!");
+        }
     }
 
     /// <summary>

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs
@@ -22,6 +22,8 @@ public class PuzzleFeedback : MonoBehaviour
 
     private bool isFlashing = false;
     
+    private PuzzleInformation puzzleInfo;
+    
     // Intervals used to determine when to flash the tile's color during the timer
     // Flash intervals
     private float errorLastIntervalTime = 0f;
@@ -39,6 +41,9 @@ public class PuzzleFeedback : MonoBehaviour
         // Get reference to the text component
         messageText = feedbackText.GetComponent<TMP_Text>();
         
+        // Identify what puzzle this script belongs to
+        puzzleInfo = GetComponentInParent<PuzzleInformation>();
+        
         // Hide popup text at start
         feedbackText.SetActive(false);
     }
@@ -48,7 +53,7 @@ public class PuzzleFeedback : MonoBehaviour
     {
         SelectableTile.cellOccupied += CellIsOccupied;
         SelectableTile.moveOutOfBounds += MoveIsOutOfBounds;
-        ResourceManager.noMoreCardUses += NoMoreCardUses;
+        ResourceManager.noCardUsagesLeft += NoMoreCardUses;
     }
     
     // Unsubscribe from events
@@ -56,7 +61,6 @@ public class PuzzleFeedback : MonoBehaviour
     {
         SelectableTile.cellOccupied -= CellIsOccupied;
         SelectableTile.moveOutOfBounds -= MoveIsOutOfBounds;
-        ResourceManager.noMoreCardUses -= NoMoreCardUses;
     }
 
     private void CellIsOccupied(SelectableTile selectableTile)
@@ -72,8 +76,9 @@ public class PuzzleFeedback : MonoBehaviour
     /// <summary>
     /// NEW: Triggered when player has no more card usages left
     /// </summary>
-    private void NoMoreCardUses()
+    private void NoMoreCardUses(PuzzleInformation puzzleInfo, string message)
     {
+        if ()
         StartFeedback(null, "No more card usages!");
     }
 

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
@@ -3,6 +3,7 @@ using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.Events;
 
 /// <summary>
 /// This script stores data regarding the resources provided during each puzzle.
@@ -12,8 +13,8 @@ using TMPro;
 /// </summary>
 public class ResourceManager : MonoBehaviour
 {
-    public static event Action noMoreCardUses;
-
+    public static event Action<PuzzleInformation, string> noCardUsagesLeft;
+    
     [Title("Resource Data", "Set the appropriate Mana and Move Card count for this puzzle.")]
     [PropertyTooltip("The starting Mana count. Set to 5 by default, but should be updated per puzzle.")]
     public int startingMana = 5;
@@ -112,7 +113,9 @@ public class ResourceManager : MonoBehaviour
         {
             Debug.Log("ResourceManager.cs >> No mana to move.");
             // PuzzleFeedback.Instance?.ShowMessage("No more mana!");
-            puzzleFeedback.ShowMessage("No more mana!");
+            string message = "No more mana!";
+            // puzzleFeedback.ShowMessage("No more mana!");
+            noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
             return false;
         }
 
@@ -124,9 +127,9 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Left card uses remaining");
 
-                    // PuzzleFeedback.Instance?.ShowMessage("No more Left card usages!");
-                    puzzleFeedback.ShowMessage("No more Left card usages!");
-                    noMoreCardUses?.Invoke();
+                    string message = "No more Left card usages!";
+                    // puzzleFeedback.ShowMessage("No more Left card usages!");
+                    noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }
 
@@ -140,9 +143,9 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Right card uses remaining");
 
-                    // PuzzleFeedback.Instance?.ShowMessage("No more Right card usages!");
-                    puzzleFeedback.ShowMessage("No more Right card usages!");
-                    noMoreCardUses?.Invoke();
+                    string message = "No more Right card usages!";
+                    // puzzleFeedback.ShowMessage("No more Right card usages!");
+                    noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }
 
@@ -156,9 +159,9 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Forward card uses remaining");
 
-                    // PuzzleFeedback.Instance?.ShowMessage("No more Forward card usages!");
-                    puzzleFeedback.ShowMessage("No more Forward card usages!");
-                    noMoreCardUses?.Invoke();
+                    string message = "No more Forward card usages!";
+                    // puzzleFeedback.ShowMessage("No more Forward card usages!");
+                    noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }
 
@@ -172,9 +175,9 @@ public class ResourceManager : MonoBehaviour
                     if (printCardDrainage)
                         Debug.Log("ResourceManager.cs >> No Back card uses remaining");
 
-                    // PuzzleFeedback.Instance?.ShowMessage("No more Back card usages!");
-                    puzzleFeedback.ShowMessage("No more Back card usages!");
-                    noMoreCardUses?.Invoke();
+                    string message = "No more Back card usages!";
+                    // puzzleFeedback.ShowMessage("No more Back card usages!");
+                    noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }
 

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/ResourceManager.cs
@@ -13,7 +13,7 @@ using UnityEngine.Events;
 /// </summary>
 public class ResourceManager : MonoBehaviour
 {
-    public static event Action<PuzzleInformation, string> noCardUsagesLeft;
+    public UnityEvent<PuzzleInformation, string> noCardUsagesLeft;
     
     [Title("Resource Data", "Set the appropriate Mana and Move Card count for this puzzle.")]
     [PropertyTooltip("The starting Mana count. Set to 5 by default, but should be updated per puzzle.")]
@@ -112,9 +112,7 @@ public class ResourceManager : MonoBehaviour
         if (currentMana <= 0)
         {
             Debug.Log("ResourceManager.cs >> No mana to move.");
-            // PuzzleFeedback.Instance?.ShowMessage("No more mana!");
             string message = "No more mana!";
-            // puzzleFeedback.ShowMessage("No more mana!");
             noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
             return false;
         }
@@ -128,7 +126,6 @@ public class ResourceManager : MonoBehaviour
                         Debug.Log("ResourceManager.cs >> No Left card uses remaining");
 
                     string message = "No more Left card usages!";
-                    // puzzleFeedback.ShowMessage("No more Left card usages!");
                     noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }
@@ -144,7 +141,6 @@ public class ResourceManager : MonoBehaviour
                         Debug.Log("ResourceManager.cs >> No Right card uses remaining");
 
                     string message = "No more Right card usages!";
-                    // puzzleFeedback.ShowMessage("No more Right card usages!");
                     noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }
@@ -176,7 +172,6 @@ public class ResourceManager : MonoBehaviour
                         Debug.Log("ResourceManager.cs >> No Back card uses remaining");
 
                     string message = "No more Back card usages!";
-                    // puzzleFeedback.ShowMessage("No more Back card usages!");
                     noCardUsagesLeft?.Invoke(GetComponentInParent<PuzzleInformation>(), message);
                     return false;
                 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
@@ -42,10 +42,10 @@ public class SelectableTile : MonoBehaviour
     public bool printStartingPosition;
 
     // Event fired when a move is blocked by an occupied cell
-    public static event Action<SelectableTile> cellOccupied;
+    public static event Action<PuzzleInformation, SelectableTile> cellOccupied;
 
     // Event fired when a move is out of bounds
-    public static event Action<SelectableTile> moveOutOfBounds;
+    public static event Action<PuzzleInformation, SelectableTile> moveOutOfBounds;
 
     // Subscribe to events
     private void OnEnable()
@@ -149,7 +149,7 @@ public class SelectableTile : MonoBehaviour
         Debug.Log($"SelectableTile.cs >> BLOCKED: Cell at ({coordX},{coordZ}) is occupied.");
 
         // Fire off an event to say that a cell is occupied
-        cellOccupied?.Invoke(this);
+        cellOccupied?.Invoke(GetComponentInParent<PuzzleInformation>(), this);
         return false;
     }
 
@@ -167,7 +167,7 @@ public class SelectableTile : MonoBehaviour
             Debug.Log("SelectableTile.cs >> BLOCKED: Outside grid – no mana spent");
 
             // Fire off an event to say that the move is out of bounds
-            moveOutOfBounds?.Invoke(this);
+            moveOutOfBounds?.Invoke(GetComponentInParent<PuzzleInformation>(), this);
             return true;
         }
 


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`test/event-testing-for-issue-383`](https://github.com/Precipice-Games/untitled-26/tree/test/event-testing-for-issue-383) into [`issue/383-improve-puzzle-feedback-onscreen-text`](https://github.com/Precipice-Games/untitled-26/tree/issue/383-improve-puzzle-feedback-onscreen-text).
- This PR is related to #383.

### In-depth Details
- Merging two commits related to my work on [#383](https://github.com/Precipice-Games/untitled-26/issues/383).
- I was reworking the event system for invalid moves during puzzles, because the original one relied on a singleton that I removed in 0cdf955.
     - Now, each prefab has its own feedback text inside of the puzzle's UI canvas.
- Because of that, I wanted to make sure the events for invalid moves were not being received by _all_ instances of the puzzle feedback text.
- I did this with the two new event types, based on either invalid action:
     - SelectableTile-based events use a public static event Action<>.
     - Resource-based events use a public UnityEvent<>, which is assigned in the inspector.
     - Both event types use the same parameter sequence.
- The PuzzleInformation parameter is used to ensure that this event is being fired at the right prefab's onscreen text.
     - See 6b43587 for more information.