### PR TITLE
Fixed #549 | Resolved Missing Reference for ExitPuzzleButton.cs

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/RuneCircle.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/RuneCircle.cs
@@ -94,7 +94,7 @@ public class RuneCircle : MonoBehaviour
         if (!PuzzleInfoFound()) return;
 
         // Play rune circle sound effect
-        SFXManager.Instance.PlayRuneCircle();
+        if (SFXManager.Instance != null) SFXManager.Instance.PlayRuneCircle();
         
         // If the puzzle has already been completed, teleport to the other rune circle.
         if (puzzleInfo.puzzleSolved == true)
@@ -105,6 +105,7 @@ public class RuneCircle : MonoBehaviour
 
         // Assign the transform position of the player's respawn location to be on the starting rune circle.
         exitPuzzleButton.currentRuneCircle = this;
+        exitPuzzleButton.player = player;
         exitPuzzleButton.respawnLocation = new Vector3(transform.position.x, transform.position.y + 1.0f, transform.position.z);
 
         // If the puzzle has not been completed, trigger the


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/549-ensure-exit-buttons-work-for-all-puzzle-prefabs`](https://github.com/Precipice-Games/untitled-26/tree/issue/549-ensure-exit-buttons-work-for-all-puzzle-prefabs) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #549.

### In-depth Details
- During the alpha demo, we noticed that we were unable to exit from some of the puzzles via the "Exit" button.
- I found the problem and resolved it in 1cd2e5e.
- I added a line to RuneCircle.cs to ensure that the `player` reference for ExitPuzzleButton.cs was not empty.
- The empty variable was blocking the exit request.