### PR TITLE
Fixed #569 | Rune circle interaction trigger

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Art/3D Models/World Materials/Snow.mat
+++ b/00 Unity Proj/Untitled-26/Assets/Art/3D Models/World Materials/Snow.mat
@@ -116,8 +116,8 @@ Material:
     - _XRMotionVectorsPass: 1
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 1, g: 0, b: 1, a: 1}
-    - _Color: {r: 1, g: 0, b: 1, a: 1}
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -53774,6 +53774,50 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_MoveAction
+      value: 
+      objectReference: {fileID: -4265220639702670642, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_PointAction
+      value: 
+      objectReference: {fileID: 6465669424074167628, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_ActionsAsset
+      value: 
+      objectReference: {fileID: -944628639613478452, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_CancelAction
+      value: 
+      objectReference: {fileID: 415226467710996720, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_SubmitAction
+      value: 
+      objectReference: {fileID: -7838565490652668449, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_LeftClickAction
+      value: 
+      objectReference: {fileID: 2385318201707490742, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_RightClickAction
+      value: 
+      objectReference: {fileID: -8671386872515475562, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_MiddleClickAction
+      value: 
+      objectReference: {fileID: -1127534448034733246, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_ScrollWheelAction
+      value: 
+      objectReference: {fileID: 1932992226813233507, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_TrackedDevicePositionAction
+      value: 
+      objectReference: {fileID: -7472464319981792750, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
+    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
+      propertyPath: m_TrackedDeviceOrientationAction
+      value: 
+      objectReference: {fileID: 1139918243457856847, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
     - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
@@ -2070,6 +2070,14 @@ PrefabInstance:
       propertyPath: gridX
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 4943596135170749970, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 2064143266}
+    - target: {fileID: 4943596135170749970, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: currentRuneCircle
+      value: 
+      objectReference: {fileID: 2071926729}
     - target: {fileID: 5018615782271576797, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
       propertyPath: m_LocalPosition.z
       value: 3
@@ -2724,8 +2732,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 54.879906, y: 1.7007141, z: 166.97644}
-  m_Center: {x: -39.18118, y: -153.65, z: 190.08414}
+  m_Size: {x: 54.879906, y: 7.1476746, z: 166.97644}
+  m_Center: {x: -39.18118, y: -163.82185, z: 190.08414}
 --- !u!114 &1074486373 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3432335786353409372, guid: cd77f075d3ae50f43890f44b657a1a52, type: 3}
@@ -2899,6 +2907,14 @@ PrefabInstance:
       propertyPath: gridX
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 4943596135170749970, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 2064143266}
+    - target: {fileID: 4943596135170749970, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: currentRuneCircle
+      value: 
+      objectReference: {fileID: 2106538891}
     - target: {fileID: 5018615782271576797, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
       propertyPath: m_LocalPosition.z
       value: 5
@@ -5619,6 +5635,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 5438321986708604092, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
   m_PrefabInstance: {fileID: 2064143264}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2071926729 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3625183002538320219, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+  m_PrefabInstance: {fileID: 1021214702}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 245062b318bd734438bf0438b5bf4871, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::RuneCircle
 --- !u!1 &2081925795 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1053923620404659715, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
@@ -5664,6 +5691,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!114 &2106538891 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3625183002538320219, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+  m_PrefabInstance: {fileID: 1153222202}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 245062b318bd734438bf0438b5bf4871, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::RuneCircle
 --- !u!1001 &2144424999
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -2107,6 +2107,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 410468428}
     - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 0
@@ -6189,6 +6193,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 410468428}
     - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: originalColor.g
       value: 0
@@ -10421,6 +10429,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 410468428}
     - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 1
@@ -17096,6 +17108,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 410468428}
     - target: {fileID: 5018615782271576797, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.x
       value: -82.9

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/RuneCircle.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/RuneCircle.cs
@@ -28,18 +28,6 @@ public class RuneCircle : MonoBehaviour
     // Static event to notify subscribers of game state changes
     public static event Action<PuzzleInformation> puzzleTriggered;
 
-    // Subscribe to events
-    private void OnEnable()
-    {
-        PlayerInteraction.playerInteraction += Interaction;
-    }
-
-    // Unsubscribe from events
-    private void OnDisable()
-    {
-        PlayerInteraction.playerInteraction -= Interaction;
-    }
-
     /// <summary>
     /// Called when the Player's collider enters the rune circle collider.
     /// This sets inCircle to true and invokes the playerInCircle event
@@ -66,6 +54,7 @@ public class RuneCircle : MonoBehaviour
     /// <param name="other"></param>
     private void OnTriggerExit(Collider other)
     {
+        Debug.Log("RuneCircle.cs >> Player exited rune circle.");
         if (other.CompareTag("Player"))
         {
             playerInCircle?.Invoke(false);
@@ -87,14 +76,19 @@ public class RuneCircle : MonoBehaviour
     /// </summary>
     public void Interaction()
     {
+        Debug.Log("RuneCircle.cs >> Player interacted with rune circle.");
         // If the player is not standing on the rune circle, break out.
         if (!inCircle) return;
+        Debug.Log("RuneCircle.cs >> inCircle = " + inCircle);
 
         // If there's no puzzle info, break out.
         if (!PuzzleInfoFound()) return;
 
         // Play rune circle sound effect
-        SFXManager.Instance.PlayRuneCircle();
+        if (SFXManager.Instance != null)
+        {
+            SFXManager.Instance.PlayRuneCircle();
+        }
         
         // If the puzzle has already been completed, teleport to the other rune circle.
         if (puzzleInfo.puzzleSolved == true)


### PR DESCRIPTION
Overview
- Pulling the latest version of [`issue/569-fix-rune-circle-interaction-trigger`](https://github.com/Precipice-Games/untitled-26/tree/issue/569-fix-rune-circle-interaction-trigger) into [`dev`](https://github.com/Precipice-Games/untitled-26.git)
- Fixes #569 

In-Depth Details
- Added a null check for SFXManager singleton
- Removed rune circles as a listener of playerInteraction event
- Fixed Mother Island and Oasis puzzle exit button missing references