### PR TITLE
Fixed #560 | Update Occupancy Map

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
@@ -179,10 +179,17 @@ public class SelectableTile : MonoBehaviour
     /// </summary>
     private void ResetTiles()
     {
+        // clear the current cell before resetting position
+        gridManager.ClearCell(gridX, gridZ);
+
+        // move tile back to starting position
         gridX = startingGridX;
         gridZ = startingGridZ;
 
         transform.localPosition = gridManager.GridToWorld(gridX, gridZ);
+
+        // Ensure grid manager is up to date with tile position
+        gridManager.PlaceTile(this, gridX, gridZ);
 
         // Reset tile color after reset
         if (tileType == TileType.ManaWell)


### PR DESCRIPTION
Overview
- Pulling the latest version of [`issue/560-fix-puzzle-reset-bug`](https://github.com/Precipice-Games/untitled-26/tree/issue/560-fix-puzzle-reset-bug) into [`dev`](https://github.com/Precipice-Games/untitled-26.git)
- Fixes #560

In-Depth Details 
- Correctly updates the occupancy map of GridManager.cs on puzzle reset