### PR TITLE
Fixed #573 | Snap Player to Moving Platforms

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/FlowerBasePuzzleNew.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/FlowerBasePuzzleNew.prefab
@@ -365,9 +365,9 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: End Rune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -790,9 +790,9 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: StartRune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1709,7 +1709,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1800,7 +1800,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2328,6 +2328,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Model (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -2669,6 +2673,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Name
       value: Model
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
@@ -365,9 +365,9 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: End Rune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -967,9 +967,9 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: StartRune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2771,7 +2771,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2862,7 +2862,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3752,6 +3752,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Model (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -4093,6 +4097,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Name
       value: Model
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
@@ -365,9 +365,9 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: End Rune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -967,9 +967,9 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: StartRune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2771,7 +2771,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2862,7 +2862,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3752,6 +3752,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Model (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -4093,6 +4097,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Name
       value: Model
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
@@ -367,9 +367,9 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: End Rune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -972,9 +972,9 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: StartRune
-  m_TagString: Untagged
+  m_TagString: Ground
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2785,7 +2785,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2876,7 +2876,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3769,6 +3769,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Model (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -4110,6 +4114,10 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Name
       value: Model
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
+      propertyPath: m_Layer
+      value: 7
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -2337,6 +2337,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9191018659038673785, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: puzzleSolved
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 925581002351369635, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -4017,7 +4021,7 @@ Transform:
   m_GameObject: {fileID: 319399733}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -57.98, y: 8.89, z: 67.2}
+  m_LocalPosition: {x: -49.4, y: 10.35, z: 56.3}
   m_LocalScale: {x: 7.9, y: 0.4, z: 7.98}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4066,6 +4070,7 @@ MonoBehaviour:
   moveDistance: 15
   speed: 8.57
   isActive: 0
+  charController: {fileID: 0}
 --- !u!65 &319399737
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -6339,6 +6344,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9191018659038673785, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: puzzleSolved
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 925581002351369635, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -7053,7 +7062,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7306501694993207284, guid: b9390f6ae2b784147aa63217cb70c386, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -352.8
+      value: -337.00998
       objectReference: {fileID: 0}
     - target: {fileID: 7306501694993207284, guid: b9390f6ae2b784147aa63217cb70c386, type: 3}
       propertyPath: m_LocalPosition.y
@@ -7061,7 +7070,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7306501694993207284, guid: b9390f6ae2b784147aa63217cb70c386, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 241.3
+      value: 230.63
       objectReference: {fileID: 0}
     - target: {fileID: 7306501694993207284, guid: b9390f6ae2b784147aa63217cb70c386, type: 3}
       propertyPath: m_LocalRotation.w
@@ -7901,7 +7910,7 @@ Transform:
   m_GameObject: {fileID: 612413730}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 147.53998, y: 2.16, z: 68.99751}
+  m_LocalPosition: {x: 150.71, y: 1.72, z: 66.85}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -10322,6 +10331,10 @@ PrefabInstance:
       propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9191018659038673785, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: puzzleSolved
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 925581002351369635, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -10511,7 +10524,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -19.13
+      value: -3.34
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalPosition.y
@@ -10519,7 +10532,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 237.16
+      value: 226.49
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalRotation.w
@@ -12610,7 +12623,7 @@ Transform:
   m_GameObject: {fileID: 929181072}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.3314202, z: 0, w: 0.9434833}
-  m_LocalPosition: {x: -33.49, y: 9.76, z: 39.75}
+  m_LocalPosition: {x: -34.2, y: 9.76, z: 42.2}
   m_LocalScale: {x: 7.9, y: 0.4, z: 7.98}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -12632,6 +12645,7 @@ MonoBehaviour:
   moveDistance: 15
   speed: 8.57
   isActive: 0
+  charController: {fileID: 0}
 --- !u!65 &929181075
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -13755,7 +13769,7 @@ Transform:
   m_GameObject: {fileID: 1060740123}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -85.24, y: 11.38, z: 89.12}
+  m_LocalPosition: {x: -74.11, y: 9.61, z: 78.71}
   m_LocalScale: {x: 7.9, y: 0.4, z: 7.98}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -13775,8 +13789,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   moveDirection: {x: 0, y: 1, z: 0}
   moveDistance: 15
-  speed: 7.59
-  isActive: 0
+  speed: 6
+  isActive: 1
+  charController: {fileID: 0}
 --- !u!65 &1060740126
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -14664,7 +14679,7 @@ Transform:
   m_GameObject: {fileID: 1164520297}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -147.78004, y: -10.8, z: 30.537506}
+  m_LocalPosition: {x: -146.2, y: -9.3, z: 28}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -16326,7 +16341,7 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 0b06b7f862134ee4fb3d76e6fc3e66a5, type: 2}
     - target: {fileID: 3397337548393501967, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.4199829
+      value: 15.6
       objectReference: {fileID: 0}
     - target: {fileID: 3397337548393501967, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.y
@@ -16334,7 +16349,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3397337548393501967, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 187.5375
+      value: 178.1
       objectReference: {fileID: 0}
     - target: {fileID: 3397337548393501967, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalRotation.w
@@ -16881,19 +16896,19 @@ PrefabInstance:
     - target: {fileID: 3432335786353409372, guid: cd77f075d3ae50f43890f44b657a1a52, type: 3}
       propertyPath: 'respawnLocations.Array.data[0]'
       value: 
-      objectReference: {fileID: 340828971}
+      objectReference: {fileID: 612413731}
     - target: {fileID: 3432335786353409372, guid: cd77f075d3ae50f43890f44b657a1a52, type: 3}
       propertyPath: 'respawnLocations.Array.data[1]'
       value: 
-      objectReference: {fileID: 813844465}
+      objectReference: {fileID: 340828971}
     - target: {fileID: 3432335786353409372, guid: cd77f075d3ae50f43890f44b657a1a52, type: 3}
       propertyPath: 'respawnLocations.Array.data[2]'
       value: 
-      objectReference: {fileID: 1892284748}
+      objectReference: {fileID: 813844465}
     - target: {fileID: 3432335786353409372, guid: cd77f075d3ae50f43890f44b657a1a52, type: 3}
       propertyPath: 'respawnLocations.Array.data[3]'
       value: 
-      objectReference: {fileID: 612413731}
+      objectReference: {fileID: 1892284748}
     - target: {fileID: 3432335786353409372, guid: cd77f075d3ae50f43890f44b657a1a52, type: 3}
       propertyPath: 'respawnLocations.Array.data[4]'
       value: 
@@ -17491,7 +17506,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::YarnPlatformTrigger
   platforms:
-  - {fileID: 929181074}
+  - {fileID: 1728649764}
   - {fileID: 1982907262}
   - {fileID: 1783707275}
   - {fileID: 1060740125}
@@ -18632,7 +18647,7 @@ Transform:
   m_GameObject: {fileID: 1728649761}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0.16160385, z: 0, w: 0.98685575}
-  m_LocalPosition: {x: -39.95, y: 9.7, z: 50.61}
+  m_LocalPosition: {x: -45.21, y: 10.33, z: 44.46}
   m_LocalScale: {x: 7.9, y: 0.4, z: 7.98}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -18680,7 +18695,8 @@ MonoBehaviour:
   moveDirection: {x: 1, y: 0, z: 1}
   moveDistance: 15
   speed: 8.57
-  isActive: 0
+  isActive: 1
+  charController: {fileID: 0}
 --- !u!65 &1728649765
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -24262,7 +24278,7 @@ Transform:
   m_GameObject: {fileID: 1783707273}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -76.66, y: 9.69, z: 80.4}
+  m_LocalPosition: {x: -68.88, y: 11.59, z: 70.02}
   m_LocalScale: {x: 7.9, y: 0.4, z: 7.98}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -24282,8 +24298,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   moveDirection: {x: 1, y: 0, z: 1}
   moveDistance: 15
-  speed: 9
-  isActive: 0
+  speed: 8
+  isActive: 1
+  charController: {fileID: 0}
 --- !u!65 &1783707276
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -24592,7 +24609,7 @@ Transform:
   m_GameObject: {fileID: 1892284747}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 281.34, y: 0.63, z: 136.22}
+  m_LocalPosition: {x: 281.34, y: 1.17, z: 136.22}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -25102,7 +25119,7 @@ Transform:
   m_GameObject: {fileID: 1982907260}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -68.09, y: 6.33, z: 69.15}
+  m_LocalPosition: {x: -58.16, y: 8.34, z: 62.92}
   m_LocalScale: {x: 7.9, y: 0.4, z: 7.98}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -25123,7 +25140,8 @@ MonoBehaviour:
   moveDirection: {x: 1, y: 1, z: 1}
   moveDistance: 14.01
   speed: 9
-  isActive: 0
+  isActive: 1
+  charController: {fileID: 0}
 --- !u!65 &1982907263
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -26567,7 +26585,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 6018484093985562617, guid: 282e0d0bc9f8b47458787f8303d58b00, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -337.82
+      value: -322.03
       objectReference: {fileID: 0}
     - target: {fileID: 6018484093985562617, guid: 282e0d0bc9f8b47458787f8303d58b00, type: 3}
       propertyPath: m_LocalPosition.y
@@ -26575,7 +26593,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6018484093985562617, guid: 282e0d0bc9f8b47458787f8303d58b00, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 232.52
+      value: 221.85
       objectReference: {fileID: 0}
     - target: {fileID: 6018484093985562617, guid: 282e0d0bc9f8b47458787f8303d58b00, type: 3}
       propertyPath: m_LocalRotation.w
@@ -26716,7 +26734,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1562532093982906886, guid: ce5fb46def1204e41901117282703312, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -298
+      value: -282.1
       objectReference: {fileID: 0}
     - target: {fileID: 1562532093982906886, guid: ce5fb46def1204e41901117282703312, type: 3}
       propertyPath: m_LocalPosition.y
@@ -26724,7 +26742,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1562532093982906886, guid: ce5fb46def1204e41901117282703312, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 177.6
+      value: 167.2
       objectReference: {fileID: 0}
     - target: {fileID: 1562532093982906886, guid: ce5fb46def1204e41901117282703312, type: 3}
       propertyPath: m_LocalRotation.w

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerMovement.cs
@@ -68,7 +68,10 @@ public class PlayerMovement : MonoBehaviour
     public float JumpTimeout = 0.50f;
     [Tooltip("Time required to pass before entering the fall state. Useful for walking down stairs")]
     public float FallTimeout = 0.15f;
-    
+
+    // Track moving platform for parkour
+    private MovingPlatform currentPlatform; 
+
     // Subscribe to events
     private void OnEnable()
     {
@@ -112,6 +115,12 @@ public class PlayerMovement : MonoBehaviour
         // Keep a direct sync to avoid one-frame event timing differences on fast machines.
         currentGameState = GameStateManager.CurrentGameState;
         ConfigurePlayerOnGameState();
+
+        if(currentPlatform != null && !IsStandingOn(currentPlatform))
+        {
+            currentPlatform.Clear(charController);
+            currentPlatform = null;
+        }
     }
 
     private void FixedUpdate()
@@ -294,5 +303,36 @@ public class PlayerMovement : MonoBehaviour
         {
             _verticalVelocity += Gravity * Time.fixedDeltaTime;
         }
+    }
+
+    private void OnControllerColliderHit(ControllerColliderHit hit)
+    {
+        if (hit.normal.y < .5f) return;
+
+        var platform = hit.collider.GetComponent<MovingPlatform>();
+        if (platform == null) return;
+        
+        if(currentPlatform != platform)
+        {
+            if (currentPlatform != null)
+            {
+                currentPlatform.Clear(charController);
+            }
+
+            currentPlatform = platform;
+            currentPlatform.Set(charController);
+        }
+    }
+
+    private bool IsStandingOn(MovingPlatform platform)
+    {
+        float checkDistance = 1.1f;
+        RaycastHit hit;
+        Vector3 origin = transform.position + Vector3.up * 0.1f;
+        if (Physics.Raycast(origin, Vector3.down, out hit, checkDistance))
+        {
+            return (hit.collider != null && hit.collider.transform.IsChildOf(platform.transform));
+        }
+        return false;
     }
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/MovingPlatform.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/MovingPlatform.cs
@@ -6,13 +6,18 @@ public class MovingPlatform : MonoBehaviour
     public float moveDistance = 15f; // how far it travels
     public float speed = 12f; // speed
 
-    public bool isActive = false; 
+    public bool isActive = false;
 
     private Vector3 startPos;
+    private Vector3 lastPos;
+
+    [SerializeField]
+    private CharacterController charController;
 
     void Start()
     {
         startPos = transform.position;
+        lastPos = transform.position;
     }
 
     void Update()
@@ -23,24 +28,56 @@ public class MovingPlatform : MonoBehaviour
         transform.position = startPos + moveDirection.normalized * movement;
     }
 
+    // Move the player along with platform after platform has moved this frame
+    void LateUpdate()
+    {
+        Vector3 delta = transform.position - lastPos;
+        if (delta != Vector3.zero)
+        {
+            if (charController != null)
+            {
+                charController.Move(delta);
+            }
+        }
+
+        lastPos = transform.position;
+    }
+
     public void ActivatePlatform() //Attach player to platform
     {
         isActive = true;
     }
 
-    private void OnCollisionEnter(Collision collision)
+    // Note: parenting the moving platform to the object is not ideal because it interferes with characterController behavior
+    private void OnCollisionEnter(Collision other)
     {
-        if (collision.gameObject.CompareTag("Player"))
+        if (other.gameObject.CompareTag("Player"))
         {
-            collision.transform.SetParent(transform);
+            charController = other.gameObject.GetComponent<CharacterController>();
         }
     }
 
-    private void OnCollisionExit(Collision collision) //Detach player when leaving
+    private void OnCollisionExit(Collision other) //Detach player when leaving
     {
-        if (collision.gameObject.CompareTag("Player"))
+        if (other.gameObject.CompareTag("Player"))
         {
-            collision.transform.SetParent(null);
+            if (charController != null)
+            {
+                charController = null;
+            }
+        }
+    }
+
+    public void Set(CharacterController controller)
+    {
+        charController = controller;
+    }
+
+    public void Clear(CharacterController controller)
+    {
+        if (charController == controller)
+        {
+            charController = null;
         }
     }
 }

--- a/00 Unity Proj/Untitled-26/ProjectSettings/DynamicsManager.asset
+++ b/00 Unity Proj/Untitled-26/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 13
+  serializedVersion: 22
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -16,11 +17,11 @@ PhysicsManager:
   m_EnableAdaptiveForce: 0
   m_ClothInterCollisionDistance: 0.1
   m_ClothInterCollisionStiffness: 0.2
-  m_ContactsGeneration: 1
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
+  m_InvokeCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
   m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
@@ -31,6 +32,13 @@ PhysicsManager:
   m_WorldSubdivisions: 8
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
-  m_EnableUnifiedHeightmaps: 1
+  m_ImprovedPatchFriction: 0
+  m_GenerateOnTriggerStayEvents: 1
   m_SolverType: 0
   m_DefaultMaxAngularSpeed: 50
+  m_ScratchBufferChunkCount: 4
+  m_CurrentBackendId: 4072204805
+  m_FastMotionThreshold: 3.4028235e+38
+  m_SceneBuffersReleaseInterval: 0
+  m_ReleaseSceneBuffers: 0
+  m_LogVerbosity: 3


### PR DESCRIPTION
Overview
- Pulling the latest version of [`issue/573-snap-player-to-moving-platforms`](https://github.com/Precipice-Games/untitled-26/tree/issue/573-snap-player-to-moving-platforms) into [`dev`](https://github.com/Precipice-Games/untitled-26.git)
- Fixes #573 

In-Depth Details
- When player is on a moving platform, make the player a child of that platform. Update the transform of the player via characterController hit