### PR TITLE
Fixed #636 | Restored Player Reference for Exit Button in Puzzle Mode

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -85,17 +85,17 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
-    "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "issue/564-pre-beta-character-controller-physics",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.typescript.service.memoryLimit.init&quot;: &quot;true&quot;,
+    &quot;Standalone Player.Start Unity.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;issue/564-pre-beta-character-controller-physics&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RunManager" selected="Standalone Player.Start Unity">
     <configuration name="Standalone Player" type="RunUnityExe" factoryName="Unity Executable">
       <option name="EXE_PATH" value="$USER_HOME$/Desktop/v2.0.4\Isles of Ethor.exe" />
@@ -127,7 +127,7 @@
       <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
-    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
+    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost" useMixedMode="false">
       <option name="allowRunningInParallel" value="false" />
       <option name="listenPortForConnections" value="false" />
       <option name="pid" />
@@ -138,7 +138,6 @@
       <option name="selectedOptions">
         <list />
       </option>
-      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to" type="UnityDevicePlayer" factoryName="UnityAttachToDevicePlayer">

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/RuneCircle.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/RuneCircle.cs
@@ -85,10 +85,7 @@ public class RuneCircle : MonoBehaviour
         if (!PuzzleInfoFound()) return;
 
         // Play rune circle sound effect
-        if (SFXManager.Instance != null)
-        {
-            SFXManager.Instance.PlayRuneCircle();
-        }
+        if (SFXManager.Instance != null) SFXManager.Instance.PlayRuneCircle();
         
         // If the puzzle has already been completed, teleport to the other rune circle.
         if (puzzleInfo.puzzleSolved == true)
@@ -99,6 +96,7 @@ public class RuneCircle : MonoBehaviour
 
         // Assign the transform position of the player's respawn location to be on the starting rune circle.
         exitPuzzleButton.currentRuneCircle = this;
+        exitPuzzleButton.player = player;
         exitPuzzleButton.respawnLocation = new Vector3(transform.position.x, transform.position.y + 1.0f, transform.position.z);
 
         // If the puzzle has not been completed, trigger the


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`bug/636-repair-exit-button-on-flower-puzzle-prefab`](https://github.com/Precipice-Games/untitled-26/tree/bug/636-repair-exit-button-on-flower-puzzle-prefab) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #636.

### In-depth Details
- Restored a critical line in RuneCircle.cs from 1cd2e5e.

<p>
<img src="https://github.com/user-attachments/assets/f7026048-2307-4309-98b7-b52ce0b307c6" alt="Line" width="100%" style="max-width: 100%;">
</p>

- This line is used to ensure that the exit button has a reference to the Player.
- It is absolutely **critical** that this line is available in all builds, especially the final, otherwise we will get soft locked in a puzzle.