### PR TITLE
Related to #640 | Attached SelectableTilesParent.cs to Ice, Mother, and Oasis Puzzles

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -5,10 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/PuzzleFeedback.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTilesParent.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTilesParent.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Oasis_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Oasis_Island.unity" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -63,7 +61,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "issue/574-add-hover-vfx-to-puzzle-tiles",
+    "git-widget-placeholder": "issue/640-ensure-selectabletilesparent-all-tiles",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
@@ -336,7 +336,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1186,7 +1186,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1541,7 +1541,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 6
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 0.6981132, g: 0.6981132, b: 0.6981132, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1719,7 +1719,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 0
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1896,7 +1896,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2005,6 +2005,7 @@ MonoBehaviour:
   gridManager: {fileID: 0}
   resourceManager: {fileID: 7213066574574228598}
   printInvalidMoves: 1
+  printHoverDetection: 0
 --- !u!1 &4785314922009797101
 GameObject:
   m_ObjectHideFlags: 0
@@ -2389,7 +2390,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3102,7 +3103,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3411,7 +3412,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
@@ -159,7 +159,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 3
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -337,7 +337,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1191,7 +1191,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1548,7 +1548,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 6
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 0.6981132, g: 0.6981132, b: 0.6981132, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1727,7 +1727,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 0
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1905,7 +1905,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2015,6 +2015,7 @@ MonoBehaviour:
   gridManager: {fileID: 0}
   resourceManager: {fileID: 7213066574574228598}
   printInvalidMoves: 1
+  printHoverDetection: 0
 --- !u!1 &4785314922009797101
 GameObject:
   m_ObjectHideFlags: 0
@@ -2400,7 +2401,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2578,7 +2579,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 3
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3116,7 +3117,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3426,7 +3427,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3678,7 +3679,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 2792611444543776699}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -2327,7 +2327,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2504,7 +2504,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 4
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2927,7 +2927,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3350,7 +3350,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 4
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -9288,7 +9288,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -9465,7 +9465,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 8
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -9806,7 +9806,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -12467,7 +12467,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 4
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -12726,7 +12726,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 3
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -13214,7 +13214,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -14730,7 +14730,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 8
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -19797,7 +19797,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -20548,7 +20548,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -20838,7 +20838,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -21102,7 +21102,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 4
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -22239,7 +22239,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 4
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -22763,6 +22763,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 588839293333666835, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
   m_PrefabInstance: {fileID: 372399995}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &784155936 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1284802655190286773, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
+  m_PrefabInstance: {fileID: 372399995}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 169a640392ed4572949cb0c8fa80e788, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SelectableTilesParent
 --- !u!1001 &789651786
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -23749,7 +23760,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -34784,7 +34795,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -40156,7 +40167,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -51187,7 +51198,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 2
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -56505,7 +56516,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 4
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -56846,7 +56857,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -58717,7 +58728,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 8
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -58976,7 +58987,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 3
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -60416,7 +60427,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 6
   gridManager: {fileID: 1508110539}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 784155936}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -65893,7 +65904,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -66070,7 +66081,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -71318,7 +71329,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 3
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -71495,7 +71506,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -72411,6 +72422,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::PuzzleBlocker
   StateManager: {fileID: 1604888279}
   puzzleMode: 0
+--- !u!114 &1437640445 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1284802655190286773, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
+  m_PrefabInstance: {fileID: 1437640441}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1437640442}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 169a640392ed4572949cb0c8fa80e788, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SelectableTilesParent
 --- !u!1001 &1442416483
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -72725,7 +72747,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -83150,7 +83172,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -83772,7 +83794,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 5
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -91306,7 +91328,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 3
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -91564,7 +91586,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 1
   gridManager: {fileID: 89625282}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1437640445}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -92422,7 +92444,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 6
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -92776,7 +92798,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -97761,7 +97783,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -98364,7 +98386,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 3
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -98719,6 +98741,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8014860526984270938, guid: 52fcc2c214e11dd46bc310e39123907a, type: 3}
   m_PrefabInstance: {fileID: 1919866982}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1932135444 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1284802655190286773, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
+  m_PrefabInstance: {fileID: 60844291}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 169a640392ed4572949cb0c8fa80e788, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SelectableTilesParent
 --- !u!1001 &1938058303
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -98951,7 +98984,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 8
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -99490,7 +99523,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 7
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -100373,7 +100406,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 8
   gridManager: {fileID: 51436021}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1932135444}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -111567,7 +111600,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 5
   gridManager: {fileID: 89625282}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 1437640445}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -188,7 +188,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 3
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -366,7 +366,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 7
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -544,7 +544,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 6
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -812,7 +812,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 5
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -1546,7 +1546,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 4
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2422,6 +2422,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7199852587322879966, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
   m_PrefabInstance: {fileID: 111690256}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &111690260 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2792611444543776699, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+  m_PrefabInstance: {fileID: 111690256}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 169a640392ed4572949cb0c8fa80e788, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SelectableTilesParent
 --- !u!1 &120266135
 GameObject:
   m_ObjectHideFlags: 0
@@ -2491,7 +2502,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 4
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2669,7 +2680,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 7
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -2949,7 +2960,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 8
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3204,7 +3215,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 7
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3382,7 +3393,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 2
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3662,7 +3673,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 7
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -3942,7 +3953,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 7
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -4278,7 +4289,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 2
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -4696,7 +4707,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 8
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -4874,7 +4885,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -5451,7 +5462,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -5629,7 +5640,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 8
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -5807,7 +5818,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 4
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -6493,7 +6504,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -6770,7 +6781,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 3
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -6948,7 +6959,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 3
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -7402,7 +7413,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -7682,7 +7693,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -7860,7 +7871,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 1
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -8069,7 +8080,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 7
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -8247,7 +8258,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 9
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -8491,7 +8502,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 4
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -8669,7 +8680,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 4
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -8947,6 +8958,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7369719981292622885, guid: 75f929da6991db4438cb51a68aa3a685, type: 3}
   m_PrefabInstance: {fileID: 351107574}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &732417351 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2792611444543776699, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+  m_PrefabInstance: {fileID: 1274900496}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1274900500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 169a640392ed4572949cb0c8fa80e788, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SelectableTilesParent
 --- !u!1 &740714156
 GameObject:
   m_ObjectHideFlags: 0
@@ -9016,7 +9038,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -9194,7 +9216,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 2
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -9372,7 +9394,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -9758,7 +9780,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 3
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -10476,6 +10498,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7199852587322879966, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
   m_PrefabInstance: {fileID: 788873473}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &788873477 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2792611444543776699, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+  m_PrefabInstance: {fileID: 788873473}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 169a640392ed4572949cb0c8fa80e788, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SelectableTilesParent
 --- !u!1001 &796736234
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -10779,7 +10812,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 8
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -11059,7 +11092,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 5
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -11237,7 +11270,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 2
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -11415,7 +11448,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 6
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -11593,7 +11626,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 2
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -12465,7 +12498,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 5
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -13382,7 +13415,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 7
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -13560,7 +13593,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 9
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -13738,7 +13771,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 6
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -14163,7 +14196,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 3
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -14899,7 +14932,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 8
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -15518,7 +15551,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 3
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -15762,7 +15795,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 6
   gridManager: {fileID: 788873474}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 788873477}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -15940,7 +15973,7 @@ MonoBehaviour:
   gridX: 6
   gridZ: 6
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -16118,7 +16151,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 9
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -18199,7 +18232,7 @@ MonoBehaviour:
   gridX: 1
   gridZ: 4
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -18742,7 +18775,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 7
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -19078,7 +19111,7 @@ MonoBehaviour:
   gridX: 9
   gridZ: 6
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -24195,7 +24228,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 2
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -24373,7 +24406,7 @@ MonoBehaviour:
   gridX: 5
   gridZ: 4
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -24709,7 +24742,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 6
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -25020,7 +25053,7 @@ MonoBehaviour:
   gridX: 8
   gridZ: 8
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -25606,7 +25639,7 @@ MonoBehaviour:
   gridX: 3
   gridZ: 6
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -25886,7 +25919,7 @@ MonoBehaviour:
   gridX: 7
   gridZ: 4
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -26075,7 +26108,7 @@ MonoBehaviour:
   gridX: 2
   gridZ: 7
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -26457,7 +26490,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 9
   gridManager: {fileID: 1274900497}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 732417351}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
@@ -26772,7 +26805,7 @@ MonoBehaviour:
   gridX: 4
   gridZ: 6
   gridManager: {fileID: 111690257}
-  selectableTilesParent: {fileID: 0}
+  selectableTilesParent: {fileID: 111690260}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/640-ensure-selectabletilesparent-all-tiles`](https://github.com/Precipice-Games/untitled-26/tree/issue/640-ensure-selectabletilesparent-all-tiles) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR is related to #640.

### In-depth Details
- Just made sure the SelectableTilesParent.cs script is attached to every tile in every scene.
- There is one SelectableTilesParent.cs script per puzzle, and it sits on the Islands game object.
- These must be attached in order for the feedback system to operate properly.