### PR TITLE
Hotfix | Patched a Bug with Color Reset on Puzzles

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -5,8 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Oasis_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Oasis_Island.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -61,7 +63,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "issue/640-ensure-selectabletilesparent-all-tiles",
+    "git-widget-placeholder": "issue/574-add-hover-vfx-to-puzzle-tiles",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
@@ -1364,7 +1364,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 1284802655190286773}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &8005034875218007865
@@ -2005,6 +2005,7 @@ MonoBehaviour:
   gridManager: {fileID: 0}
   resourceManager: {fileID: 7213066574574228598}
   printInvalidMoves: 1
+  printHoverDetection: 0
 --- !u!1 &4785314922009797101
 GameObject:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -112923,18 +112923,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: p1DriftIsland (1)
       objectReference: {fileID: 0}
-    - target: {fileID: 405139856658798943, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 563326666085521974, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
     - target: {fileID: 588839293333666835, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 1.6
@@ -112959,14 +112951,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 942123610933921151, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 1194170782476251622, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 1373633058433270611, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 15
@@ -112999,10 +112983,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 15
       objectReference: {fileID: 0}
-    - target: {fileID: 1588683769779273750, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 1640623606830934790, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: width
       value: 5
@@ -113011,10 +112991,6 @@ PrefabInstance:
       propertyPath: height
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 1659925710443679340, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: m_BlockingMask.m_Bits
-      value: 247
-      objectReference: {fileID: 0}
     - target: {fileID: 1712450131070757306, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p1DriftIsland (13)
@@ -113022,18 +112998,6 @@ PrefabInstance:
     - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: debugMode
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 0.13333334
       objectReference: {fileID: 0}
     - target: {fileID: 1872530666423440456, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
@@ -113051,10 +113015,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
     - target: {fileID: 2392832193953854197, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.37486
@@ -113111,18 +113071,10 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 2492369896358051882, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 2543200966874335288, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
     - target: {fileID: 2595629101245525352, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p1DriftIsland (12)
@@ -113139,28 +113091,8 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 18
       objectReference: {fileID: 0}
-    - target: {fileID: 2894027827498185238, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: debugMode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3072390140186109677, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
@@ -113251,10 +113183,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3552629102073594185, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 3582445771482792929, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 3
@@ -113319,32 +113247,12 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
     - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 4377554390259353776, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: debugMode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 4455366089648708046, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4472860653813335475, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
@@ -113379,22 +113287,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 0.8352941
-      objectReference: {fileID: 0}
-    - target: {fileID: 4799146664536455604, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 4943596135170749970, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: player
       value: 
@@ -113411,10 +113303,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
     - target: {fileID: 5059960743704218579, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p1DriftIsland (14)
@@ -113431,14 +113319,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 5982847078855375376, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 6241378083209524425, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 6
@@ -113459,10 +113339,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6321783586416998415, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
     - target: {fileID: 6337408609227900163, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p1DriftIsland (8)
@@ -113475,18 +113351,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 6753946847105957717, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
-    - target: {fileID: 6812597502080116913, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 6919531168105839388, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p1DriftIsland (3)
@@ -113507,22 +113371,6 @@ PrefabInstance:
       propertyPath: debugMode
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 7032101937263023470, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 9
@@ -113535,10 +113383,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 7080484599821343335, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 7120682438755080915, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 12
@@ -113599,10 +113443,6 @@ PrefabInstance:
       propertyPath: printStartingValues
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7250865128602065745, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 7295780280858452554, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 3
@@ -113643,18 +113483,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: p1DriftIsland (2)
       objectReference: {fileID: 0}
-    - target: {fileID: 7983341034897042044, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 8066876773405094797, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p1DriftIsland (7)
       objectReference: {fileID: 0}
-    - target: {fileID: 8112916970843022624, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 8121130190396842554, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
@@ -113695,10 +113527,6 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8403321909210574967, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 8449441648833188324, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 9
@@ -113720,10 +113548,6 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: gridManager
-      value: 
-      objectReference: {fileID: 1800943169}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridX
       value: 5
       objectReference: {fileID: 0}
@@ -113731,26 +113555,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8843377798655896561, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: 'm_Materials.Array.data[0]'
-      value: 
-      objectReference: {fileID: 2100000, guid: d57ef13cf0af88a44b94bccaa8189b2b, type: 2}
     - target: {fileID: 9007823278109169485, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 15
@@ -113771,6 +113575,14 @@ PrefabInstance:
       propertyPath: startTile
       value: 
       objectReference: {fileID: 611145321}
+    - target: {fileID: 0}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_BlockingMask.m_Bits
+      value: 247
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 8169518140372392218, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
@@ -23,12 +23,12 @@ public class SelectableTile : MonoBehaviour
     public TileType tileType = TileType.Normal;
 
     public enum GustDirection
-{
-    Up,
-    Down,
-    Left,
-    Right
-}
+    {
+        Up,
+        Down,
+        Left,
+        Right
+    }
 
 public GustDirection gustDirection;
 
@@ -90,15 +90,21 @@ public GustDirection gustDirection;
 
         // Set color based on tile type
         // For now, ManaWell tiles are purple so we can test them visually.
-        if (tileType == TileType.ManaWell)
-        {
-            // rend.material.color = Color.magenta;
-            rend.sharedMaterial.color = Color.magenta;
-        }
+        // if (tileType == TileType.ManaWell)
+        // {
+        //     // rend.material.color = Color.magenta;
+        //     rend.sharedMaterial.color = Color.magenta;
+        // }
 
         // Changed to rend.SharedMaterial to prevent memory leaks
         // in the scene since this script is using [ExecuteAlways].
         
+        // originalColor = rend.sharedMaterial.color;
+        // rend.sharedMaterial.color = originalColor;
+        if (originalColor != null)
+        {
+            Debug.Log("SelectableTile.cs >> The original color of this tile is: " + originalColor);
+        }
         // originalColor = rend.sharedMaterial.color;
         // rend.sharedMaterial.color = originalColor;
         


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/574-add-hover-vfx-to-puzzle-tiles`](https://github.com/Precipice-Games/untitled-26/tree/issue/574-add-hover-vfx-to-puzzle-tiles) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR is a hotfix related to puzzle tiles.

### In-depth Details
- Quick fix to the puzzle tiles when resetting a puzzle.
- I noticed that the colors on some tiles were resetting, even if nothing had been done.
- It seems to work now for all puzzles.