### PR TITLE
Fixed #665 | Recreated Event System in Ice Island

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -90739,6 +90739,85 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8014860526984270938, guid: 52fcc2c214e11dd46bc310e39123907a, type: 3}
   m_PrefabInstance: {fileID: 1660162466}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1663831788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1663831791}
+  - component: {fileID: 1663831790}
+  - component: {fileID: 1663831789}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1663831789
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1663831788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.UI.InputSystemUIInputModule
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_MoveAction: {fileID: -4265220639702670642, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &1663831790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1663831788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.EventSystems.EventSystem
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1663831791
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1663831788}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1665068702
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -112494,107 +112573,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 06c1bec38da134aab85cb41d899c1c32, type: 3}
---- !u!1001 &4948310389671487639
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_MoveAction
-      value: 
-      objectReference: {fileID: -4265220639702670642, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_PointAction
-      value: 
-      objectReference: {fileID: 6465669424074167628, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_ActionsAsset
-      value: 
-      objectReference: {fileID: -944628639613478452, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_CancelAction
-      value: 
-      objectReference: {fileID: 415226467710996720, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_SubmitAction
-      value: 
-      objectReference: {fileID: -7838565490652668449, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LeftClickAction
-      value: 
-      objectReference: {fileID: 2385318201707490742, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_RightClickAction
-      value: 
-      objectReference: {fileID: -8671386872515475562, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_MiddleClickAction
-      value: 
-      objectReference: {fileID: -1127534448034733246, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_ScrollWheelAction
-      value: 
-      objectReference: {fileID: 1932992226813233507, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_TrackedDevicePositionAction
-      value: 
-      objectReference: {fileID: -7472464319981792750, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 446106262223623158, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_TrackedDeviceOrientationAction
-      value: 
-      objectReference: {fileID: 1139918243457856847, guid: 398bff137a68b47458beb240fdd12a92, type: 3}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4252315353629880175, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5008670874782649107, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
-      propertyPath: m_Name
-      value: EventSystem
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 1710d0def16b0e64ca15a0462b10aed0, type: 3}
 --- !u!1001 &7795512651711934439
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -113591,14 +113569,6 @@ PrefabInstance:
       propertyPath: startTile
       value: 
       objectReference: {fileID: 611145321}
-    - target: {fileID: 0}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 0}
-      propertyPath: m_BlockingMask.m_Bits
-      value: 247
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:
     - {fileID: 8169518140372392218, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
@@ -113740,8 +113710,8 @@ SceneRoots:
   - {fileID: 4508045225757819367}
   - {fileID: 594807609}
   - {fileID: 1098756137}
-  - {fileID: 4948310389671487639}
   - {fileID: 1422275508}
   - {fileID: 4029354900766978087}
   - {fileID: 2095135721}
   - {fileID: 3981474138339879985}
+  - {fileID: 1663831791}


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/665-fix-ice-island-pause-bug`](https://github.com/Precipice-Games/untitled-26/tree/issue/665-fix-ice-island-pause-bug) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR is related to #665.

### In-depth Details
- Recreated the EventSystem game object in Ice_Island.unity (ed6cd0b).
- This fixed the problem of entering a puzzle and then leaving, and then trying to pause, and not being able to click anything.