### PR TITLE
Fixed #675 | Added Layer Mask Parsing 

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -5,10 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -63,7 +60,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "issue/574-add-hover-vfx-to-puzzle-tiles",
+    "git-widget-placeholder": "dev",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/FlowerBasePuzzleNew.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/FlowerBasePuzzleNew.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5542912942022859257}
   - component: {fileID: 4272864839946960334}
   - component: {fileID: 5512107360585776755}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -192,7 +192,7 @@ GameObject:
   - component: {fileID: 4179740133415273008}
   - component: {fileID: 7093079210516756760}
   - component: {fileID: 2549888048032672565}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -365,7 +365,7 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: End Rune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -440,7 +440,7 @@ GameObject:
   - component: {fileID: 1034313677803190943}
   - component: {fileID: 5351886452548070166}
   - component: {fileID: 6389536348917577084}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -613,7 +613,7 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: StartRune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -688,7 +688,7 @@ GameObject:
   - component: {fileID: 5457771306051330994}
   - component: {fileID: 3715649125927333295}
   - component: {fileID: 3479704110299356731}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -865,7 +865,7 @@ GameObject:
   - component: {fileID: 5231381797051820232}
   - component: {fileID: 1788808401797866365}
   - component: {fileID: 1244910741730082733}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: EndTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1043,7 +1043,7 @@ GameObject:
   - component: {fileID: 309107811372590528}
   - component: {fileID: 4759651532516943100}
   - component: {fileID: 5978776441588120618}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: StartTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1356,7 +1356,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1447,7 +1447,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1796,7 +1796,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2142,7 +2142,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5542912942022859257}
   - component: {fileID: 4272864839946960334}
   - component: {fileID: 5512107360585776755}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -192,7 +192,7 @@ GameObject:
   - component: {fileID: 8931899725991205104}
   - component: {fileID: 5025002967551595757}
   - component: {fileID: 6432267523721855295}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -365,7 +365,7 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: End Rune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -440,7 +440,7 @@ GameObject:
   - component: {fileID: 5645746178308066833}
   - component: {fileID: 9059629293011494203}
   - component: {fileID: 1935316655362665216}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -617,7 +617,7 @@ GameObject:
   - component: {fileID: 7045734070655998070}
   - component: {fileID: 7012397342193439338}
   - component: {fileID: 2994768156443577359}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -794,7 +794,7 @@ GameObject:
   - component: {fileID: 6530514183576964366}
   - component: {fileID: 5689756566394007165}
   - component: {fileID: 6388347264209649682}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -967,7 +967,7 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: StartRune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -1042,7 +1042,7 @@ GameObject:
   - component: {fileID: 4406865920393537666}
   - component: {fileID: 4064603128251208255}
   - component: {fileID: 2527591170935224815}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1219,7 +1219,7 @@ GameObject:
   - component: {fileID: 453642476825720023}
   - component: {fileID: 8509538877335474834}
   - component: {fileID: 8005034875218007865}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1396,7 +1396,7 @@ GameObject:
   - component: {fileID: 5231381797051820232}
   - component: {fileID: 1788808401797866365}
   - component: {fileID: 1244910741730082733}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: EndTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1574,7 +1574,7 @@ GameObject:
   - component: {fileID: 309107811372590528}
   - component: {fileID: 4759651532516943100}
   - component: {fileID: 5978776441588120618}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: StartTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1752,7 +1752,7 @@ GameObject:
   - component: {fileID: 3261880673261627557}
   - component: {fileID: 2275969997962342486}
   - component: {fileID: 9113206126131355125}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2069,7 +2069,7 @@ GameObject:
   - component: {fileID: 8734686047623891108}
   - component: {fileID: 6321783586416998415}
   - component: {fileID: 2808763504185811519}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2246,7 +2246,7 @@ GameObject:
   - component: {fileID: 3685197665221182148}
   - component: {fileID: 563326666085521974}
   - component: {fileID: 227008895814519879}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2423,7 +2423,7 @@ GameObject:
   - component: {fileID: 7523907909368201943}
   - component: {fileID: 6625943618315678091}
   - component: {fileID: 7506839496352779529}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2600,7 +2600,7 @@ GameObject:
   - component: {fileID: 5886979120025315524}
   - component: {fileID: 942123610933921151}
   - component: {fileID: 43864182441971540}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2772,7 +2772,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2863,7 +2863,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2959,7 +2959,7 @@ GameObject:
   - component: {fileID: 1780069663387497229}
   - component: {fileID: 3034548341052867213}
   - component: {fileID: 6655442478861624289}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3268,7 +3268,7 @@ GameObject:
   - component: {fileID: 8379635494583041761}
   - component: {fileID: 4441267795168363193}
   - component: {fileID: 2765207070866698723}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3494,7 +3494,6 @@ MonoBehaviour:
   moveRightUses: 2
   moveForwardUses: 2
   moveBackUses: 2
-  puzzleFeedback: {fileID: 2186891206686781560}
   manaLabel: {fileID: 4244620660118580199}
   leftLabel: {fileID: 1230731256228544730}
   rightLabel: {fileID: 4912949784702118134}
@@ -3519,7 +3518,7 @@ GameObject:
   - component: {fileID: 2308668415581002923}
   - component: {fileID: 2543200966874335288}
   - component: {fileID: 7978220242805462963}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3755,7 +3754,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4101,7 +4100,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5542912942022859257}
   - component: {fileID: 4272864839946960334}
   - component: {fileID: 1361485055277093178}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -192,7 +192,7 @@ GameObject:
   - component: {fileID: 8931899725991205104}
   - component: {fileID: 5025002967551595757}
   - component: {fileID: 674050429062326758}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -365,7 +365,7 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: End Rune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -440,7 +440,7 @@ GameObject:
   - component: {fileID: 5645746178308066833}
   - component: {fileID: 9059629293011494203}
   - component: {fileID: 5668346888246670449}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -617,7 +617,7 @@ GameObject:
   - component: {fileID: 7045734070655998070}
   - component: {fileID: 7012397342193439338}
   - component: {fileID: 7049456268961169745}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -794,7 +794,7 @@ GameObject:
   - component: {fileID: 6530514183576964366}
   - component: {fileID: 5689756566394007165}
   - component: {fileID: 1527905477152698449}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -967,7 +967,7 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: StartRune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -1042,7 +1042,7 @@ GameObject:
   - component: {fileID: 4406865920393537666}
   - component: {fileID: 4064603128251208255}
   - component: {fileID: 3146548009398657931}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1219,7 +1219,7 @@ GameObject:
   - component: {fileID: 453642476825720023}
   - component: {fileID: 8509538877335474834}
   - component: {fileID: 4641199904726581519}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1396,7 +1396,7 @@ GameObject:
   - component: {fileID: 5231381797051820232}
   - component: {fileID: 1788808401797866365}
   - component: {fileID: 1303838987071360981}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: EndTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1574,7 +1574,7 @@ GameObject:
   - component: {fileID: 309107811372590528}
   - component: {fileID: 4759651532516943100}
   - component: {fileID: 7421929144077174582}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: StartTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1752,7 +1752,7 @@ GameObject:
   - component: {fileID: 3261880673261627557}
   - component: {fileID: 2275969997962342486}
   - component: {fileID: 1692342746788151541}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2069,7 +2069,7 @@ GameObject:
   - component: {fileID: 8734686047623891108}
   - component: {fileID: 6321783586416998415}
   - component: {fileID: 373656486766559563}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2246,7 +2246,7 @@ GameObject:
   - component: {fileID: 3685197665221182148}
   - component: {fileID: 563326666085521974}
   - component: {fileID: 2640555398377000108}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2423,7 +2423,7 @@ GameObject:
   - component: {fileID: 7523907909368201943}
   - component: {fileID: 6625943618315678091}
   - component: {fileID: 8781985787554735920}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2600,7 +2600,7 @@ GameObject:
   - component: {fileID: 5886979120025315524}
   - component: {fileID: 942123610933921151}
   - component: {fileID: 7914251024003687447}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2772,7 +2772,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2863,7 +2863,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2959,7 +2959,7 @@ GameObject:
   - component: {fileID: 1780069663387497229}
   - component: {fileID: 3034548341052867213}
   - component: {fileID: 8632020953357628628}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3268,7 +3268,7 @@ GameObject:
   - component: {fileID: 8379635494583041761}
   - component: {fileID: 4441267795168363193}
   - component: {fileID: 6447627335958466952}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3494,7 +3494,6 @@ MonoBehaviour:
   moveRightUses: 2
   moveForwardUses: 2
   moveBackUses: 2
-  puzzleFeedback: {fileID: 0}
   manaLabel: {fileID: 4244620660118580199}
   leftLabel: {fileID: 1230731256228544730}
   rightLabel: {fileID: 4912949784702118134}
@@ -3519,7 +3518,7 @@ GameObject:
   - component: {fileID: 2308668415581002923}
   - component: {fileID: 2543200966874335288}
   - component: {fileID: 9192580670938830888}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3755,7 +3754,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4101,7 +4100,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5542912942022859257}
   - component: {fileID: 4272864839946960334}
   - component: {fileID: 462030680039650362}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -193,7 +193,7 @@ GameObject:
   - component: {fileID: 8931899725991205104}
   - component: {fileID: 5025002967551595757}
   - component: {fileID: 4595504975527966859}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -367,7 +367,7 @@ GameObject:
   - component: {fileID: 7321162161942524934}
   - component: {fileID: 6825509473540728000}
   - component: {fileID: 6284629459955097238}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: End Rune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -442,7 +442,7 @@ GameObject:
   - component: {fileID: 5645746178308066833}
   - component: {fileID: 9059629293011494203}
   - component: {fileID: 2109680602633393201}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -620,7 +620,7 @@ GameObject:
   - component: {fileID: 7045734070655998070}
   - component: {fileID: 7012397342193439338}
   - component: {fileID: 2782697071798502931}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -798,7 +798,7 @@ GameObject:
   - component: {fileID: 6530514183576964366}
   - component: {fileID: 5689756566394007165}
   - component: {fileID: 8159557790008996862}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -972,7 +972,7 @@ GameObject:
   - component: {fileID: 3624906698350998147}
   - component: {fileID: 5019277549151866532}
   - component: {fileID: 3625183002538320219}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: StartRune
   m_TagString: Ground
   m_Icon: {fileID: 0}
@@ -1047,7 +1047,7 @@ GameObject:
   - component: {fileID: 4406865920393537666}
   - component: {fileID: 4064603128251208255}
   - component: {fileID: 6489086496816542894}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (5)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1225,7 +1225,7 @@ GameObject:
   - component: {fileID: 453642476825720023}
   - component: {fileID: 8509538877335474834}
   - component: {fileID: 1793338628941162873}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1403,7 +1403,7 @@ GameObject:
   - component: {fileID: 5231381797051820232}
   - component: {fileID: 1788808401797866365}
   - component: {fileID: 75604923921128914}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: EndTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1582,7 +1582,7 @@ GameObject:
   - component: {fileID: 309107811372590528}
   - component: {fileID: 4759651532516943100}
   - component: {fileID: 3125751281091478400}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: StartTile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1761,7 +1761,7 @@ GameObject:
   - component: {fileID: 3261880673261627557}
   - component: {fileID: 2275969997962342486}
   - component: {fileID: 6951716154662205045}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (4)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2079,7 +2079,7 @@ GameObject:
   - component: {fileID: 8734686047623891108}
   - component: {fileID: 6321783586416998415}
   - component: {fileID: 6002312338352691636}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2257,7 +2257,7 @@ GameObject:
   - component: {fileID: 3685197665221182148}
   - component: {fileID: 563326666085521974}
   - component: {fileID: 7814334935528232029}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (6)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2435,7 +2435,7 @@ GameObject:
   - component: {fileID: 7523907909368201943}
   - component: {fileID: 6625943618315678091}
   - component: {fileID: 1018420845183218425}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2613,7 +2613,7 @@ GameObject:
   - component: {fileID: 5886979120025315524}
   - component: {fileID: 942123610933921151}
   - component: {fileID: 8800908044913615335}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2786,7 +2786,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3942273821399491795}
   - component: {fileID: 5218340796993907333}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2877,7 +2877,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7325537039630228397}
   - component: {fileID: 2821830542318120351}
-  m_Layer: 7
+  m_Layer: 9
   m_Name: RuneSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2973,7 +2973,7 @@ GameObject:
   - component: {fileID: 1780069663387497229}
   - component: {fileID: 3034548341052867213}
   - component: {fileID: 2857121180329872076}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (3)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3283,7 +3283,7 @@ GameObject:
   - component: {fileID: 8379635494583041761}
   - component: {fileID: 4441267795168363193}
   - component: {fileID: 8187284894119930763}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3510,7 +3510,6 @@ MonoBehaviour:
   moveRightUses: 2
   moveForwardUses: 2
   moveBackUses: 2
-  puzzleFeedback: {fileID: 0}
   manaLabel: {fileID: 4244620660118580199}
   leftLabel: {fileID: 1230731256228544730}
   rightLabel: {fileID: 4912949784702118134}
@@ -3535,7 +3534,7 @@ GameObject:
   - component: {fileID: 2308668415581002923}
   - component: {fileID: 2543200966874335288}
   - component: {fileID: 8089232956589956577}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (7)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3772,7 +3771,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4118,7 +4117,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: dedef1882a78850498d9dc638d6cb5cb, type: 3}
       propertyPath: m_Layer
-      value: 7
+      value: 9
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Flower_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Flower_Island.unity
@@ -390,7 +390,7 @@ GameObject:
   - component: {fileID: 293097771}
   - component: {fileID: 293097770}
   - component: {fileID: 293097769}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -823,7 +823,7 @@ GameObject:
   - component: {fileID: 625986850}
   - component: {fileID: 625986849}
   - component: {fileID: 625986848}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3031,7 +3031,7 @@ GameObject:
   - component: {fileID: 1429059494}
   - component: {fileID: 1429059493}
   - component: {fileID: 1429059492}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3208,7 +3208,7 @@ GameObject:
   - component: {fileID: 1485800572}
   - component: {fileID: 1485800571}
   - component: {fileID: 1485800570}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -2274,7 +2274,7 @@ GameObject:
   - component: {fileID: 157486491}
   - component: {fileID: 157486490}
   - component: {fileID: 157486489}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (32)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2451,7 +2451,7 @@ GameObject:
   - component: {fileID: 158666394}
   - component: {fileID: 158666393}
   - component: {fileID: 158666392}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (26)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2874,7 +2874,7 @@ GameObject:
   - component: {fileID: 164438371}
   - component: {fileID: 164438370}
   - component: {fileID: 164438369}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (28)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3297,7 +3297,7 @@ GameObject:
   - component: {fileID: 203640133}
   - component: {fileID: 203640132}
   - component: {fileID: 203640131}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (22)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9235,7 +9235,7 @@ GameObject:
   - component: {fileID: 263533505}
   - component: {fileID: 263533504}
   - component: {fileID: 263533503}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (34)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9412,7 +9412,7 @@ GameObject:
   - component: {fileID: 263677645}
   - component: {fileID: 263677644}
   - component: {fileID: 263677643}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (54)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9753,7 +9753,7 @@ GameObject:
   - component: {fileID: 272242140}
   - component: {fileID: 272242139}
   - component: {fileID: 272242138}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (30)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12414,7 +12414,7 @@ GameObject:
   - component: {fileID: 408128072}
   - component: {fileID: 408128071}
   - component: {fileID: 408128070}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (27)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12673,7 +12673,7 @@ GameObject:
   - component: {fileID: 412733695}
   - component: {fileID: 412733694}
   - component: {fileID: 412733693}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13161,7 +13161,7 @@ GameObject:
   - component: {fileID: 439973541}
   - component: {fileID: 439973540}
   - component: {fileID: 439973539}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (49)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14677,7 +14677,7 @@ GameObject:
   - component: {fileID: 579522412}
   - component: {fileID: 579522411}
   - component: {fileID: 579522410}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (52)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19744,7 +19744,7 @@ GameObject:
   - component: {fileID: 586997847}
   - component: {fileID: 586997846}
   - component: {fileID: 586997845}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (37)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20495,7 +20495,7 @@ GameObject:
   - component: {fileID: 642285749}
   - component: {fileID: 642285748}
   - component: {fileID: 642285747}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (45)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -20785,7 +20785,7 @@ GameObject:
   - component: {fileID: 673375102}
   - component: {fileID: 673375101}
   - component: {fileID: 673375100}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (44)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -21049,7 +21049,7 @@ GameObject:
   - component: {fileID: 688277787}
   - component: {fileID: 688277786}
   - component: {fileID: 688277785}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (24)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22186,7 +22186,7 @@ GameObject:
   - component: {fileID: 763619293}
   - component: {fileID: 763619292}
   - component: {fileID: 763619291}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (23)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -23707,7 +23707,7 @@ GameObject:
   - component: {fileID: 836370568}
   - component: {fileID: 836370567}
   - component: {fileID: 836370566}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (42)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -34742,7 +34742,7 @@ GameObject:
   - component: {fileID: 917827692}
   - component: {fileID: 917827691}
   - component: {fileID: 917827690}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (31)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -40114,7 +40114,7 @@ GameObject:
   - component: {fileID: 978787497}
   - component: {fileID: 978787496}
   - component: {fileID: 978787495}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (39)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -51145,7 +51145,7 @@ GameObject:
   - component: {fileID: 1180868106}
   - component: {fileID: 1180868105}
   - component: {fileID: 1180868104}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -56463,7 +56463,7 @@ GameObject:
   - component: {fileID: 1226919609}
   - component: {fileID: 1226919608}
   - component: {fileID: 1226919607}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (25)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -56804,7 +56804,7 @@ GameObject:
   - component: {fileID: 1242479835}
   - component: {fileID: 1242479834}
   - component: {fileID: 1242479833}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (35)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -58675,7 +58675,7 @@ GameObject:
   - component: {fileID: 1325243683}
   - component: {fileID: 1325243682}
   - component: {fileID: 1325243681}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (50)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -58934,7 +58934,7 @@ GameObject:
   - component: {fileID: 1337261722}
   - component: {fileID: 1337261721}
   - component: {fileID: 1337261720}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (21)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -60375,7 +60375,7 @@ GameObject:
   - component: {fileID: 1351079587}
   - component: {fileID: 1351079586}
   - component: {fileID: 1351079585}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -65851,7 +65851,7 @@ GameObject:
   - component: {fileID: 1408586506}
   - component: {fileID: 1408586505}
   - component: {fileID: 1408586504}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (41)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -66028,7 +66028,7 @@ GameObject:
   - component: {fileID: 1415632378}
   - component: {fileID: 1415632377}
   - component: {fileID: 1415632376}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (36)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -71276,7 +71276,7 @@ GameObject:
   - component: {fileID: 1424054410}
   - component: {fileID: 1424054409}
   - component: {fileID: 1424054408}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (20)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -71453,7 +71453,7 @@ GameObject:
   - component: {fileID: 1428293206}
   - component: {fileID: 1428293205}
   - component: {fileID: 1428293204}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (47)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -72694,7 +72694,7 @@ GameObject:
   - component: {fileID: 1456490991}
   - component: {fileID: 1456490990}
   - component: {fileID: 1456490989}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (29)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -83119,7 +83119,7 @@ GameObject:
   - component: {fileID: 1541993807}
   - component: {fileID: 1541993806}
   - component: {fileID: 1541993805}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (38)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -83741,7 +83741,7 @@ GameObject:
   - component: {fileID: 1571330268}
   - component: {fileID: 1571330267}
   - component: {fileID: 1571330266}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (33)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -91370,7 +91370,7 @@ GameObject:
   - component: {fileID: 1726927088}
   - component: {fileID: 1726927087}
   - component: {fileID: 1726927086}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (19)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -91629,7 +91629,7 @@ GameObject:
   - component: {fileID: 1739471988}
   - component: {fileID: 1739471987}
   - component: {fileID: 1739471986}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p2DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -92486,7 +92486,7 @@ GameObject:
   - component: {fileID: 1827881781}
   - component: {fileID: 1827881780}
   - component: {fileID: 1827881779}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (40)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -92663,7 +92663,7 @@ GameObject:
   - component: {fileID: 1837369718}
   - component: {fileID: 1837369717}
   - component: {fileID: 1837369722}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -92840,7 +92840,7 @@ GameObject:
   - component: {fileID: 1844928702}
   - component: {fileID: 1844928701}
   - component: {fileID: 1844928700}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (43)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -97825,7 +97825,7 @@ GameObject:
   - component: {fileID: 1849428741}
   - component: {fileID: 1849428740}
   - component: {fileID: 1849428739}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (48)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -98428,7 +98428,7 @@ GameObject:
   - component: {fileID: 1890701369}
   - component: {fileID: 1890701368}
   - component: {fileID: 1890701367}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (18)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -99026,7 +99026,7 @@ GameObject:
   - component: {fileID: 1942289031}
   - component: {fileID: 1942289030}
   - component: {fileID: 1942289029}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (53)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -99565,7 +99565,7 @@ GameObject:
   - component: {fileID: 1997892752}
   - component: {fileID: 1997892751}
   - component: {fileID: 1997892750}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (46)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -100448,7 +100448,7 @@ GameObject:
   - component: {fileID: 2059943333}
   - component: {fileID: 2059943332}
   - component: {fileID: 2059943331}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: DriftIsland (51)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -111201,7 +111201,7 @@ GameObject:
   - component: {fileID: 2129601381}
   - component: {fileID: 2129601380}
   - component: {fileID: 2129601385}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -111643,7 +111643,7 @@ GameObject:
   - component: {fileID: 2141377683}
   - component: {fileID: 2141377682}
   - component: {fileID: 2141377681}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p2DriftIsland (9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -134,7 +134,7 @@ GameObject:
   - component: {fileID: 22306279}
   - component: {fileID: 22306278}
   - component: {fileID: 22306277}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -312,7 +312,7 @@ GameObject:
   - component: {fileID: 32274491}
   - component: {fileID: 32274490}
   - component: {fileID: 32274489}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (38)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -490,7 +490,7 @@ GameObject:
   - component: {fileID: 62297703}
   - component: {fileID: 62297702}
   - component: {fileID: 62297701}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -758,7 +758,7 @@ GameObject:
   - component: {fileID: 73144709}
   - component: {fileID: 73144708}
   - component: {fileID: 73144707}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1492,7 +1492,7 @@ GameObject:
   - component: {fileID: 86506674}
   - component: {fileID: 86506673}
   - component: {fileID: 86506672}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (22)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2448,7 +2448,7 @@ GameObject:
   - component: {fileID: 120266139}
   - component: {fileID: 120266138}
   - component: {fileID: 120266137}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2626,7 +2626,7 @@ GameObject:
   - component: {fileID: 129042662}
   - component: {fileID: 129042661}
   - component: {fileID: 129042660}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (37)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2906,7 +2906,7 @@ GameObject:
   - component: {fileID: 162013011}
   - component: {fileID: 162013010}
   - component: {fileID: 162013009}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (44)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3161,7 +3161,7 @@ GameObject:
   - component: {fileID: 188855111}
   - component: {fileID: 188855110}
   - component: {fileID: 188855109}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (41)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3339,7 +3339,7 @@ GameObject:
   - component: {fileID: 217052969}
   - component: {fileID: 217052968}
   - component: {fileID: 217052967}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3619,7 +3619,7 @@ GameObject:
   - component: {fileID: 263677125}
   - component: {fileID: 263677124}
   - component: {fileID: 263677123}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (39)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3899,7 +3899,7 @@ GameObject:
   - component: {fileID: 309023798}
   - component: {fileID: 309023797}
   - component: {fileID: 309023796}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (40)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4235,7 +4235,7 @@ GameObject:
   - component: {fileID: 321353819}
   - component: {fileID: 321353818}
   - component: {fileID: 321353817}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4653,7 +4653,7 @@ GameObject:
   - component: {fileID: 370350300}
   - component: {fileID: 370350299}
   - component: {fileID: 370350298}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (42)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4831,7 +4831,7 @@ GameObject:
   - component: {fileID: 378908122}
   - component: {fileID: 378908121}
   - component: {fileID: 378908120}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (31)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5408,7 +5408,7 @@ GameObject:
   - component: {fileID: 386154994}
   - component: {fileID: 386154993}
   - component: {fileID: 386154992}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (26)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5586,7 +5586,7 @@ GameObject:
   - component: {fileID: 386709262}
   - component: {fileID: 386709261}
   - component: {fileID: 386709260}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (45)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5764,7 +5764,7 @@ GameObject:
   - component: {fileID: 389455275}
   - component: {fileID: 389455274}
   - component: {fileID: 389455273}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (10)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6450,7 +6450,7 @@ GameObject:
   - component: {fileID: 392594919}
   - component: {fileID: 392594918}
   - component: {fileID: 392594917}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (27)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6727,7 +6727,7 @@ GameObject:
   - component: {fileID: 428582383}
   - component: {fileID: 428582382}
   - component: {fileID: 428582381}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6905,7 +6905,7 @@ GameObject:
   - component: {fileID: 498357359}
   - component: {fileID: 498357358}
   - component: {fileID: 498357357}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (18)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7359,7 +7359,7 @@ GameObject:
   - component: {fileID: 587412818}
   - component: {fileID: 587412817}
   - component: {fileID: 587412816}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (29)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7639,7 +7639,7 @@ GameObject:
   - component: {fileID: 604282073}
   - component: {fileID: 604282072}
   - component: {fileID: 604282071}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (30)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7817,7 +7817,7 @@ GameObject:
   - component: {fileID: 606257971}
   - component: {fileID: 606257970}
   - component: {fileID: 606257969}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8026,7 +8026,7 @@ GameObject:
   - component: {fileID: 648112093}
   - component: {fileID: 648112092}
   - component: {fileID: 648112091}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (15)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8204,7 +8204,7 @@ GameObject:
   - component: {fileID: 648925158}
   - component: {fileID: 648925157}
   - component: {fileID: 648925156}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (50)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8448,7 +8448,7 @@ GameObject:
   - component: {fileID: 692042319}
   - component: {fileID: 692042318}
   - component: {fileID: 692042317}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (23)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8626,7 +8626,7 @@ GameObject:
   - component: {fileID: 706295974}
   - component: {fileID: 706295973}
   - component: {fileID: 706295972}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8984,7 +8984,7 @@ GameObject:
   - component: {fileID: 740714160}
   - component: {fileID: 740714159}
   - component: {fileID: 740714158}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (28)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9162,7 +9162,7 @@ GameObject:
   - component: {fileID: 747594072}
   - component: {fileID: 747594071}
   - component: {fileID: 747594070}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (12)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9340,7 +9340,7 @@ GameObject:
   - component: {fileID: 764915465}
   - component: {fileID: 764915464}
   - component: {fileID: 764915463}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (25)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9726,7 +9726,7 @@ GameObject:
   - component: {fileID: 779035488}
   - component: {fileID: 779035487}
   - component: {fileID: 779035486}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (9)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -10758,7 +10758,7 @@ GameObject:
   - component: {fileID: 821285922}
   - component: {fileID: 821285921}
   - component: {fileID: 821285920}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (46)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11038,7 +11038,7 @@ GameObject:
   - component: {fileID: 849067809}
   - component: {fileID: 849067808}
   - component: {fileID: 849067807}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (24)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11216,7 +11216,7 @@ GameObject:
   - component: {fileID: 863695836}
   - component: {fileID: 863695835}
   - component: {fileID: 863695834}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11394,7 +11394,7 @@ GameObject:
   - component: {fileID: 871273195}
   - component: {fileID: 871273194}
   - component: {fileID: 871273193}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11572,7 +11572,7 @@ GameObject:
   - component: {fileID: 875459051}
   - component: {fileID: 875459050}
   - component: {fileID: 875459049}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (8)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12281,6 +12281,18 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8899465276041152975, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8899465276041152975, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8899465276041152975, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8940854874939092907, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -12444,7 +12456,7 @@ GameObject:
   - component: {fileID: 902964700}
   - component: {fileID: 902964699}
   - component: {fileID: 902964698}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13361,7 +13373,7 @@ GameObject:
   - component: {fileID: 1049313796}
   - component: {fileID: 1049313795}
   - component: {fileID: 1049313794}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (13)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13539,7 +13551,7 @@ GameObject:
   - component: {fileID: 1053114240}
   - component: {fileID: 1053114239}
   - component: {fileID: 1053114238}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (51)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13717,7 +13729,7 @@ GameObject:
   - component: {fileID: 1054600202}
   - component: {fileID: 1054600201}
   - component: {fileID: 1054600200}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (35)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14142,7 +14154,7 @@ GameObject:
   - component: {fileID: 1103179045}
   - component: {fileID: 1103179044}
   - component: {fileID: 1103179043}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14878,7 +14890,7 @@ GameObject:
   - component: {fileID: 1167788897}
   - component: {fileID: 1167788896}
   - component: {fileID: 1167788895}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (43)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15497,7 +15509,7 @@ GameObject:
   - component: {fileID: 1212971315}
   - component: {fileID: 1212971314}
   - component: {fileID: 1212971313}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15741,7 +15753,7 @@ GameObject:
   - component: {fileID: 1231519505}
   - component: {fileID: 1231519504}
   - component: {fileID: 1231519503}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15919,7 +15931,7 @@ GameObject:
   - component: {fileID: 1262902551}
   - component: {fileID: 1262902550}
   - component: {fileID: 1262902549}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (34)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16097,7 +16109,7 @@ GameObject:
   - component: {fileID: 1274075236}
   - component: {fileID: 1274075235}
   - component: {fileID: 1274075234}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (48)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18178,7 +18190,7 @@ GameObject:
   - component: {fileID: 1597430616}
   - component: {fileID: 1597430615}
   - component: {fileID: 1597430614}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (19)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -18721,7 +18733,7 @@ GameObject:
   - component: {fileID: 1709062924}
   - component: {fileID: 1709062923}
   - component: {fileID: 1709062922}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (16)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19057,7 +19069,7 @@ GameObject:
   - component: {fileID: 1733261146}
   - component: {fileID: 1733261145}
   - component: {fileID: 1733261144}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (36)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24174,7 +24186,7 @@ GameObject:
   - component: {fileID: 1760505303}
   - component: {fileID: 1760505302}
   - component: {fileID: 1760505301}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (11)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24352,7 +24364,7 @@ GameObject:
   - component: {fileID: 1776042001}
   - component: {fileID: 1776042000}
   - component: {fileID: 1776041999}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (20)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24688,7 +24700,7 @@ GameObject:
   - component: {fileID: 1800276764}
   - component: {fileID: 1800276763}
   - component: {fileID: 1800276762}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (33)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24999,7 +25011,7 @@ GameObject:
   - component: {fileID: 1916586429}
   - component: {fileID: 1916586428}
   - component: {fileID: 1916586427}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (47)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25585,7 +25597,7 @@ GameObject:
   - component: {fileID: 2007446756}
   - component: {fileID: 2007446755}
   - component: {fileID: 2007446754}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (32)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -25865,7 +25877,7 @@ GameObject:
   - component: {fileID: 2018630496}
   - component: {fileID: 2018630495}
   - component: {fileID: 2018630494}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (21)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -26054,7 +26066,7 @@ GameObject:
   - component: {fileID: 2054633376}
   - component: {fileID: 2054633375}
   - component: {fileID: 2054633374}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (14)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -26436,7 +26448,7 @@ GameObject:
   - component: {fileID: 2090135195}
   - component: {fileID: 2090135194}
   - component: {fileID: 2090135193}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (49)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -26751,7 +26763,7 @@ GameObject:
   - component: {fileID: 2131217175}
   - component: {fileID: 2131217174}
   - component: {fileID: 2131217173}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: p1DriftIsland (17)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs
@@ -1,3 +1,4 @@
+using System;
 using Sirenix.OdinInspector;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -12,6 +13,10 @@ public class TileSelector : MonoBehaviour
     
     // Reference to the currently selected tile
     private SelectableTile selectedTile;
+    
+    // Reference to the layer that the tiles are on to ensure
+    // the raycast only detects tiles and not other objects
+    private LayerMask layerMask;
     
     // Reference to the Player's coordinates on the grid
     private int playerGridX;
@@ -29,6 +34,11 @@ public class TileSelector : MonoBehaviour
     public bool printInvalidMoves = true;
     [PropertyTooltip("Prints out when the mouse is hovering over a tile. False by default.")]
     public bool printHoverDetection = false;
+
+    private void Awake()
+    {
+        layerMask = LayerMask.GetMask("Tiles");
+    }
 
     // Subscribe to events
     private void OnEnable()
@@ -56,7 +66,7 @@ public class TileSelector : MonoBehaviour
     public void ClickDetected()
     {
         Ray ray = Camera.main.ScreenPointToRay(Mouse.current.position.ReadValue());
-        if (Physics.Raycast(ray, out RaycastHit hit))
+        if (Physics.Raycast(ray, out RaycastHit hit, Mathf.Infinity, layerMask))
         {
             SelectableTile tile = hit.collider.GetComponent<SelectableTile>();
             if (tile != null)
@@ -80,7 +90,7 @@ public class TileSelector : MonoBehaviour
     public void HoverDetected()
     {
         Ray ray = Camera.main.ScreenPointToRay(Mouse.current.position.ReadValue());
-        if (Physics.Raycast(ray, out RaycastHit hit))
+        if (Physics.Raycast(ray, out RaycastHit hit, Mathf.Infinity, layerMask))
         {
             SelectableTile tile = hit.collider.GetComponent<SelectableTile>();
             if (tile != null)

--- a/00 Unity Proj/Untitled-26/ProjectSettings/TagManager.asset
+++ b/00 Unity Proj/Untitled-26/ProjectSettings/TagManager.asset
@@ -16,7 +16,7 @@ TagManager:
   - Interactable
   - Ground
   - Airship
-  - 
+  - Tiles
   - 
   - 
   - 


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`bug/675-add-layer-mask-parsing-to-tileselector`](https://github.com/Precipice-Games/untitled-26/tree/bug/675-add-layer-mask-parsing-to-tileselector) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #675.

### In-depth Details
- I figured out the problem with the tile selection bug on Mother Island.
- It had to do with the collider being enabled on the entire interior model, which was blocking the TileSelector.cs raycast.
     - This is because TileSelector.cs is on the PuzzleCamera, which was being blocked by the model.
- Likewise, I updated the raycast line to incorporate parsing via layer mask.
     - I created a new layer mask named Tiles.
- All tiles on all puzzle prefabs have been added to the Tiles layer.
- I also added all loose tiles apart of each instantiation to this layer as well.
- This must be done with _all_ remaining tiles on Flower Island as those remaining puzzles are added.

<p>
<img src="https://github.com/user-attachments/assets/6ed3f2fe-d981-403b-b1af-35de8d38acc6" alt="LayerMask" width="70%" style="max-width: 100%;">
</p>