### PR TITLE
Fixed #674 | Implemented Sprint Mechanic for Player

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -5,7 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/Player/Player.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/Player/Player.prefab" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Flower_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Flower_Island.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerControlsInputs.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerControlsInputs.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerMovement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerMovement.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -60,7 +64,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "dev",
+    "git-widget-placeholder": "issue/674-add-sprint-mechanic-to-skye",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
@@ -278,7 +278,19 @@ MonoBehaviour:
     m_ActionId: b7230bb6-fc9b-4f52-8b25-f5e19cb2c2ba
     m_ActionName: 'Player/Next[/Keyboard/2]'
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6211892080048543029}
+        m_TargetAssemblyTypeName: PlayerControlsInputs, Assembly-CSharp
+        m_MethodName: PlayerSprint
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: 641cd816-40e6-41b4-8c3d-04687c349290
     m_ActionName: 'Player/Sprint[/Keyboard/leftShift]'
   - m_PersistentCalls:

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
@@ -21,6 +21,13 @@ public class PlayerControlsInputs : MonoBehaviour
 		move = context.ReadValue<Vector2>();
 	}
 	
+	/// <summary>
+	/// Takes in the Player's sprint input to determine the speed of the Player
+	/// inside PlayerMovement.cs. If nothing is detected from here, then the Player
+	/// defaults to walking speed. However, if sprint is true, then the speed is
+	/// changed to sprintSpeed.
+	/// </summary>
+	/// <param name="context"></param>
 	public void PlayerSprint(InputAction.CallbackContext context)
 	{
 		if (context.performed)

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerMovement.cs
@@ -25,10 +25,7 @@ public class PlayerMovement : MonoBehaviour
     // ==== Movement ====
     [Title("Movement", "Variables used for the Player's movement mechanic.")]
     [SerializeField] private float moveSpeed = 5.0f; //speed coefficient
-    [SerializeField] private float sprintSpeed = 7.0f;
-    [Tooltip("How fast the character turns to face movement direction")]
-    [Range(0.0f, 0.3f)]
-    public float RotationSmoothTime = 0.12f;
+    [SerializeField] private float sprintSpeed = 7.2f;
     private Vector3 inputDirection;
     private float speedOffset = 0.1f;
     private float playerTargetYaw;
@@ -48,18 +45,12 @@ public class PlayerMovement : MonoBehaviour
     // ========== Jumping ==========
     [Space]
     [Title("Jump", "Variables used for the Player's jumping mechanic.")]
-    
-    // UNDER CONSTRUCTION
-    // Working on jump functionality. -- Nikki
-    
-    public float jumpPower = 4.0f; // How strong the jump force is
-    public int maxJumps = 1;
-    public int jumpsRemaining;
-    [Space(10)]
+    private int maxJumps = 1;
     [Tooltip("The height the player can jump")]
     public float JumpHeight = 1.2f;
     [Tooltip("The character uses its own gravity value. The engine default is -9.81f")]
     public float Gravity = -15.0f;
+    
     [Space]
     [Title("Ground Check", "Variables used to perform ground checks for jumping.")]
     [SerializeField] private bool isGrounded;
@@ -241,7 +232,7 @@ public class PlayerMovement : MonoBehaviour
         if (grounded)
         {
             isGrounded = true; // Player is on the ground
-            jumpsRemaining = maxJumps; // Reset the jumps
+            // jumpsRemaining = maxJumps; // Reset the jumps
         }
         else
         {


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/674-add-sprint-mechanic-to-skye`](https://github.com/Precipice-Games/untitled-26/tree/issue/issue/674-add-sprint-mechanic-to-skye) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #674.

### In-depth Details
- I originally implemented the sprint mechanic while working on the pre-beta Player movement system ([#564](https://github.com/Precipice-Games/untitled-26/issues/564)).
- However, I left it out due to cross-platform polling issues.
- Now adding it back.
- The Player walks at 5.0f and sprints at 7.2f.