### PR TITLE
Fixed #687 | Changed Original Color of All Tiles to White

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
@@ -337,7 +337,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &674050429062326758
@@ -1187,7 +1187,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &3146548009398657931
@@ -1542,7 +1542,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 0.6981132, g: 0.6981132, b: 0.6981132, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &1303838987071360981
@@ -1720,7 +1720,7 @@ MonoBehaviour:
   gridZ: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &7421929144077174582
@@ -1897,7 +1897,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &1692342746788151541
@@ -2391,7 +2391,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &2640555398377000108
@@ -3104,7 +3104,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &8632020953357628628
@@ -3413,7 +3413,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &6447627335958466952

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/OasisBasePuzzle.prefab
@@ -160,7 +160,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &462030680039650362
@@ -338,7 +338,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &4595504975527966859
@@ -1192,7 +1192,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &6489086496816542894
@@ -1549,7 +1549,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 0.6981132, g: 0.6981132, b: 0.6981132, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &75604923921128914
@@ -1728,7 +1728,7 @@ MonoBehaviour:
   gridZ: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &3125751281091478400
@@ -1906,7 +1906,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &6951716154662205045
@@ -2402,7 +2402,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &7814334935528232029
@@ -2580,7 +2580,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &1018420845183218425
@@ -3118,7 +3118,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &2857121180329872076
@@ -3428,7 +3428,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &8187284894119930763
@@ -3679,7 +3679,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 2792611444543776699}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!114 &8089232956589956577

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -11120,22 +11120,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 588839293333666835, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.72
@@ -11179,22 +11163,6 @@ PrefabInstance:
     - target: {fileID: 942123610933921151, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 942123610933921151, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 942123610933921151, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 942123610933921151, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 942123610933921151, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1373633058433270611, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -11244,22 +11212,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: gridX
       value: 4
@@ -11279,22 +11231,6 @@ PrefabInstance:
     - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2392832193953854197, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalScale.x
@@ -11368,22 +11304,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2722518522013452351, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 3
@@ -11414,18 +11334,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3072390140186109677, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
@@ -11580,22 +11488,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: gridX
       value: 1
@@ -11616,22 +11508,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4272864839946960334, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: gridX
       value: 2
@@ -11646,22 +11522,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4472860653813335475, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
@@ -11707,22 +11567,6 @@ PrefabInstance:
     - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridX
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4943596135170749970, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: player
@@ -11780,22 +11624,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: gridX
       value: 2
@@ -11815,22 +11643,6 @@ PrefabInstance:
     - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5689756566394007165, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5982847078855375376, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
@@ -11872,22 +11684,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 6321783586416998415, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6321783586416998415, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6321783586416998415, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6321783586416998415, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: gridX
       value: 4
@@ -11903,22 +11699,6 @@ PrefabInstance:
     - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: gridX
@@ -11935,18 +11715,6 @@ PrefabInstance:
     - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7012397342193439338, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7032101937263023470, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -12104,18 +11872,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8509538877335474834, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 9007823278109169485, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_LocalPosition.x
       value: 9
@@ -12147,22 +11903,6 @@ PrefabInstance:
     - target: {fileID: 9059629293011494203, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 9059629293011494203, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9059629293011494203, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9059629293011494203, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9059629293011494203, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -71723,22 +71463,6 @@ PrefabInstance:
       propertyPath: startingGridZ
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1872530666423440456, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_Name
       value: p2DriftIsland (15)
@@ -71766,22 +71490,6 @@ PrefabInstance:
     - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: startingGridZ
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.a
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.b
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.g
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
-      propertyPath: originalColor.r
-      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2410265237940801771, guid: 0950a819356fd504a80677e1d46beb5a, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
@@ -1035,6 +1035,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 60.91748
       objectReference: {fileID: 0}
+    - target: {fileID: 8899465276041152975, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8899465276041152975, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8899465276041152975, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 9210433506073123366, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -189,7 +189,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &22306279
@@ -367,7 +367,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &32274491
@@ -545,7 +545,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &62297703
@@ -813,7 +813,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &73144709
@@ -1552,7 +1552,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &86506674
@@ -1863,10 +1863,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: p1DriftIsland (1)
       objectReference: {fileID: 0}
-    - target: {fileID: 140579135797805127, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: feedbackText
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 4
@@ -1877,10 +1873,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 925581002351369635, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -1915,18 +1907,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.b
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.r
-      value: 0.6981132
-      objectReference: {fileID: 0}
     - target: {fileID: 1872530666423440456, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1945,10 +1925,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2410265237940801771, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -1987,10 +1963,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2595629101245525352, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -2010,10 +1982,6 @@ PrefabInstance:
     - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3072390140186109677, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -2127,10 +2095,6 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4272864839946960334, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 2
@@ -2151,20 +2115,12 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -2186,10 +2142,6 @@ PrefabInstance:
     - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5059960743704218579, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
@@ -2230,10 +2182,6 @@ PrefabInstance:
     - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6919531168105839388, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_Name
@@ -2513,7 +2461,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &120266139
@@ -2691,7 +2639,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &129042662
@@ -2976,7 +2924,7 @@ MonoBehaviour:
   gridZ: 8
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &162013011
@@ -3231,7 +3179,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &188855111
@@ -3409,7 +3357,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &217052969
@@ -3694,7 +3642,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &263677125
@@ -3979,7 +3927,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &309023798
@@ -4315,7 +4263,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &321353819
@@ -4733,7 +4681,7 @@ MonoBehaviour:
   gridZ: 8
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &370350300
@@ -4911,7 +4859,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &378908122
@@ -5488,7 +5436,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &386154994
@@ -5666,7 +5614,7 @@ MonoBehaviour:
   gridZ: 8
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &386709262
@@ -5844,7 +5792,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &389455275
@@ -6486,7 +6434,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &392594919
@@ -6763,7 +6711,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &428582383
@@ -6941,7 +6889,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &498357359
@@ -7400,7 +7348,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &587412818
@@ -7685,7 +7633,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &604282073
@@ -7863,7 +7811,7 @@ MonoBehaviour:
   gridZ: 1
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &606257971
@@ -8072,7 +8020,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &648112093
@@ -8250,7 +8198,7 @@ MonoBehaviour:
   gridZ: 9
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &648925158
@@ -8494,7 +8442,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &692042319
@@ -8672,7 +8620,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &706295974
@@ -9030,7 +8978,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &740714160
@@ -9208,7 +9156,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &747594072
@@ -9386,7 +9334,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &764915465
@@ -9772,7 +9720,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &779035488
@@ -9908,10 +9856,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: p1DriftIsland (1)
       objectReference: {fileID: 0}
-    - target: {fileID: 140579135797805127, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: feedbackText
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 1
@@ -9922,10 +9866,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 588839293333666835, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -9968,18 +9908,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.b
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.r
-      value: 0.6981132
-      objectReference: {fileID: 0}
     - target: {fileID: 1872530666423440456, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -9998,10 +9926,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2410265237940801771, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -10040,10 +9964,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2595629101245525352, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -10063,10 +9983,6 @@ PrefabInstance:
     - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3072390140186109677, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -10180,10 +10096,6 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4272864839946960334, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 2
@@ -10204,20 +10116,12 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -10243,10 +10147,6 @@ PrefabInstance:
     - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5059960743704218579, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
@@ -10287,10 +10187,6 @@ PrefabInstance:
     - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6919531168105839388, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_Name
@@ -10809,7 +10705,7 @@ MonoBehaviour:
   gridZ: 8
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &821285922
@@ -11094,7 +10990,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &849067809
@@ -11272,7 +11168,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &863695836
@@ -11450,7 +11346,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &871273195
@@ -11628,7 +11524,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &875459051
@@ -12512,7 +12408,7 @@ MonoBehaviour:
   gridZ: 5
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &902964700
@@ -13429,7 +13325,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1049313796
@@ -13607,7 +13503,7 @@ MonoBehaviour:
   gridZ: 9
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1053114240
@@ -13785,7 +13681,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1054600202
@@ -14210,7 +14106,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1103179045
@@ -14946,7 +14842,7 @@ MonoBehaviour:
   gridZ: 8
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1167788897
@@ -15570,7 +15466,7 @@ MonoBehaviour:
   gridZ: 3
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1212971315
@@ -15814,7 +15710,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 788873474}
   selectableTilesParent: {fileID: 788873477}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1231519505
@@ -15992,7 +15888,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1262902551
@@ -16170,7 +16066,7 @@ MonoBehaviour:
   gridZ: 9
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1274075236
@@ -16310,10 +16206,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: p1DriftIsland (1)
       objectReference: {fileID: 0}
-    - target: {fileID: 140579135797805127, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: feedbackText
-      value: 
-      objectReference: {fileID: 0}
     - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 6
@@ -16325,10 +16217,6 @@ PrefabInstance:
     - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 588839293333666835, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -16370,18 +16258,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.b
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.r
-      value: 0.6981132
-      objectReference: {fileID: 0}
     - target: {fileID: 1872530666423440456, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -16401,10 +16277,6 @@ PrefabInstance:
     - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2410265237940801771, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -16442,10 +16314,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2595629101245525352, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -16473,10 +16341,6 @@ PrefabInstance:
     - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3072390140186109677, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -16594,10 +16458,6 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4272864839946960334, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 2
@@ -16617,10 +16477,6 @@ PrefabInstance:
     - target: {fileID: 4441267795168363193, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4595504975527966859, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: iceTexture
@@ -16632,10 +16488,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -16686,10 +16538,6 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 5059960743704218579, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -16733,10 +16581,6 @@ PrefabInstance:
     - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6919531168105839388, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_Name
@@ -18271,7 +18115,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1597430616
@@ -18814,7 +18658,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1709062924
@@ -19150,7 +18994,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1733261146
@@ -24267,7 +24111,7 @@ MonoBehaviour:
   gridZ: 2
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1760505303
@@ -24445,7 +24289,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1776042001
@@ -24781,7 +24625,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1800276764
@@ -25097,7 +24941,7 @@ MonoBehaviour:
   gridZ: 8
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &1916586429
@@ -25688,7 +25532,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &2007446756
@@ -25973,7 +25817,7 @@ MonoBehaviour:
   gridZ: 4
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &2018630496
@@ -26162,7 +26006,7 @@ MonoBehaviour:
   gridZ: 7
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &2054633376
@@ -26554,7 +26398,7 @@ MonoBehaviour:
   gridZ: 9
   gridManager: {fileID: 1274900497}
   selectableTilesParent: {fileID: 732417351}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &2090135195
@@ -26874,7 +26718,7 @@ MonoBehaviour:
   gridZ: 6
   gridManager: {fileID: 111690257}
   selectableTilesParent: {fileID: 111690260}
-  originalColor: {r: 1, g: 0, b: 1, a: 1}
+  originalColor: {r: 1, g: 1, b: 1, a: 1}
   highlightColor: {r: 1, g: 0.9810541, b: 0.015686274, a: 1}
   printStartingPosition: 0
 --- !u!54 &2131217175

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -5988,10 +5988,6 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 563326666085521974, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 925581002351369635, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -6020,18 +6016,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.b
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0.6981132
-      objectReference: {fileID: 0}
-    - target: {fileID: 1788808401797866365, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.r
-      value: 0.6981132
-      objectReference: {fileID: 0}
     - target: {fileID: 1872530666423440456, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -6050,10 +6034,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2275969997962342486, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2410265237940801771, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -6092,10 +6072,6 @@ PrefabInstance:
       propertyPath: gridZ
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 2543200966874335288, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2595629101245525352, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -6115,10 +6091,6 @@ PrefabInstance:
     - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3034548341052867213, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3072390140186109677, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -6228,17 +6200,9 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4064603128251208255, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4272864839946960334, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: tileType
       value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4272864839946960334, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4441267795168363193, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
@@ -6252,20 +6216,12 @@ PrefabInstance:
       propertyPath: tileType
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4441267795168363193, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridX
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4759651532516943100, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4943596135170749970, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
@@ -6279,10 +6235,6 @@ PrefabInstance:
     - target: {fileID: 5018615782271576797, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.z
       value: 7.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 5025002967551595757, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5059960743704218579, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_IsActive
@@ -6323,10 +6275,6 @@ PrefabInstance:
     - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: gridZ
       value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6625943618315678091, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
-      propertyPath: originalColor.g
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6919531168105839388, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_Name


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`bug/687-tiles-change-color-upon-reset`](https://github.com/Precipice-Games/untitled-26/tree/bug/687-tiles-change-color-upon-reset) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #687.

### In-depth Details
- I just went through all island scenes to ensure the originalColor property of all tiles is set to be white.
- This fixed the issue of some tiles turning a different color when resetting the puzzle.