### PR TITLE
Fixed #642 | Added Tile Sliding in the Puzzle

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs
@@ -37,6 +37,9 @@ public GustDirection gustDirection;
     private int startingGridZ;
     public int gridX;
     public int gridZ;
+
+    public bool slideTile = false;
+
     public Tuple<int, int> coordinates => Tuple.Create(gridX, gridZ);
 
     // Reference to the GridManager for this specific puzzle
@@ -149,7 +152,14 @@ public GustDirection gustDirection;
 
         gridManager.PlaceTile(this, gridX, gridZ);
 
-        transform.localPosition = gridManager.GridToWorld(gridX, gridZ);
+        //transform.localPosition = gridManager.GridToWorld(gridX, gridZ);
+        if(transform.localPosition != gridManager.GridToWorld(gridX, gridZ))
+        {
+            //Debug.Log(transform.localPosition != gridManager.GridToWorld(gridX, gridZ));
+            //transform.localPosition = Vector3.Lerp(transform.localPosition, gridManager.GridToWorld(gridX, gridZ), 10f * Time.deltaTime);
+            slideTile = true;
+        }
+
 
         Debug.Log($"SelectableTile.cs >> {name} moved to: ({gridX},{gridZ})");
 
@@ -220,5 +230,26 @@ public GustDirection gustDirection;
         }
 
         rend.material.color = originalColor;
+    }
+
+    private void FixedUpdate()
+    {
+        
+        if (slideTile)
+        {
+
+            if (transform.localPosition != gridManager.GridToWorld(gridX, gridZ))
+            {
+                //Debug.Log(transform.localPosition != gridManager.GridToWorld(gridX, gridZ));
+                transform.localPosition = Vector3.Lerp(transform.localPosition, gridManager.GridToWorld(gridX, gridZ), 2.5f * Time.deltaTime);
+                slideTile = true;
+            }
+            else
+            {
+                slideTile = false;
+            }
+
+        }
+
     }
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/World/IceTrees.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/World/IceTrees.cs
@@ -48,7 +48,7 @@ public class IceTrees : MonoBehaviour
     // Update is called once per frame
     void FixedUpdate()
     {
-        if (player != null)
+        if (player != null && GameStateManager.CurrentGameState != GameStateManager.GameState.Puzzle)
             transform.LookAt(player.transform.position);
     }
 }


### PR DESCRIPTION
Overview:
- Added logic in the Selectable Tile Script to allow for the tiles to slide in the grid rather than teleport into place

Details:
- During TryMove it checks to see if the tile's local position is equal to where it's supposed to be in gridToWorld - If not slideTile is true - if it is nothing happens
- Using FixedUpdate, if slideTile is true the tile moves to the correct position in the world and when it does slideTile is set to false