### PR TITLE
Fixed #639 | Added Fade In and Out for all Puzzles

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Managers/GameStateManager.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Managers/GameStateManager.prefab
@@ -223,6 +223,81 @@ MonoBehaviour:
   _bindingKey: 
   _tags: []
   _logs: []
+--- !u!1 &761738823635622024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8959081883034166936}
+  - component: {fileID: 4936377667841012181}
+  - component: {fileID: 7834181201646401058}
+  m_Layer: 5
+  m_Name: Transition Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &8959081883034166936
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761738823635622024}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3705698002293044328}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4936377667841012181
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761738823635622024}
+  m_CullTransparentMesh: 1
+--- !u!114 &7834181201646401058
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 761738823635622024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &866124180018465819
 GameObject:
   m_ObjectHideFlags: 0
@@ -3814,6 +3889,10 @@ MonoBehaviour:
   printSceneDefaults: 0
   printCanvasUpdate: 0
   printCameraUpdate: 0
+  fadePuzzleTransition: 0
+  transitionCanvasColor: {fileID: 7834181201646401058}
+  fadeInFadeOutInBetween: 0.5
+  currentFadeInFadeOutTime: 0
 --- !u!114 &2745341397233381068
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4373,6 +4452,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3735401046531317312}
+  - {fileID: 8959081883034166936}
   m_Father: {fileID: 3119200679773075960}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -84601,6 +84601,10 @@ PrefabInstance:
       propertyPath: printStateTransition
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 497008879434423276, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: transitionCanvasColor
+      value: 
+      objectReference: {fileID: 1938214698}
     - target: {fileID: 617803613672485369, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0.9992676
@@ -84608,6 +84612,14 @@ PrefabInstance:
     - target: {fileID: 617803613672485369, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 121.70703
+      objectReference: {fileID: 0}
+    - target: {fileID: 761738823635622024, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_Name
+      value: TransitionCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 761738823635622024, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 772468068223735368, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_SizeDelta.x
@@ -84725,6 +84737,10 @@ PrefabInstance:
       propertyPath: dialogueCamera
       value: 
       objectReference: {fileID: 8600581230760321560}
+    - target: {fileID: 1963081915272111325, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: transitionCanvasColor
+      value: 
+      objectReference: {fileID: 1938214698}
     - target: {fileID: 1963081915272111325, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: loadingComplete.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -85149,6 +85165,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: 0.49926758
       objectReference: {fileID: 0}
+    - target: {fileID: 7834181201646401058, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8140290260097337490, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 2
@@ -85260,6 +85280,14 @@ PrefabInstance:
     - target: {fileID: 8940854874939092907, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959081883034166936, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.1499
+      objectReference: {fileID: 0}
+    - target: {fileID: 8959081883034166936, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.2677
       objectReference: {fileID: 0}
     - target: {fileID: 8985972691484417835, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_SizeDelta.x
@@ -98910,6 +98938,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8014860526984270938, guid: 52fcc2c214e11dd46bc310e39123907a, type: 3}
   m_PrefabInstance: {fileID: 1938058303}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1938214698 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7834181201646401058, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+  m_PrefabInstance: {fileID: 1604888278}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
 --- !u!1001 &1938785189
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
@@ -6,6 +6,7 @@ using Unity.Cinemachine;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 using UnityEngine.Video;
 
 /// <summary>
@@ -58,6 +59,11 @@ public class ViewManager : MonoBehaviour
     public bool printCanvasUpdate = false;
     [PropertyTooltip("Print out camera updates. False by default.")]
     public bool printCameraUpdate = false;
+
+    public bool fadePuzzleTransition = false;
+    public Image transitionCanvasColor;
+    public float fadeInFadeOutInBetween = 0.5f;
+    public float currentFadeInFadeOutTime = 0f;
 
     private void Awake()
     {
@@ -135,9 +141,9 @@ public class ViewManager : MonoBehaviour
         cameras.Add(puzzleCamera);
         puzzleUI = puzzleInfo.canvas;
         uiCanvases.Add(puzzleUI);
-        
-        // Notify GameStateManager that we've detected a puzzle switch.
-        puzzleSwitchDetected.Invoke();
+
+        fadePuzzleTransition = true;
+
     }
 
     /// <summary>
@@ -324,4 +330,61 @@ public class ViewManager : MonoBehaviour
         loadingVideoPlayer.time = 0;
         loadingComplete?.Invoke();
     }
+
+    private void FixedUpdate()
+    {
+
+        if (fadePuzzleTransition)
+        {
+            //transitionCanvasColor = GameObject.Find("TransitionCanvas").GetComponent<Image>();
+            transitionCanvasColor.gameObject.SetActive(true);
+
+            if (transitionCanvasColor != null && transitionCanvasColor.color.a < 1)
+            {
+                Color newColor = transitionCanvasColor.color;
+
+                newColor.a = newColor.a + Time.deltaTime;
+
+                transitionCanvasColor.color = newColor; //fade in over time
+
+            }
+            else
+            {
+                //timer in between fade in and out to give some visual rest
+                if (currentFadeInFadeOutTime < fadeInFadeOutInBetween)
+                {
+                    currentFadeInFadeOutTime += Time.deltaTime;
+                }
+                else
+                {
+                    fadePuzzleTransition = false;
+                    // Notify GameStateManager that we've detected a puzzle switch.
+                    puzzleSwitchDetected.Invoke();
+                }
+
+            }
+
+        }
+        else
+        {
+
+            if (transitionCanvasColor != null && transitionCanvasColor.color.a >= 0)
+            {
+
+                Color newColor = transitionCanvasColor.color;
+
+                newColor.a = newColor.a - Time.deltaTime;
+
+                transitionCanvasColor.color = newColor; //fade out over time
+
+            }
+            else if (transitionCanvasColor.gameObject.activeInHierarchy && transitionCanvasColor.color.a <= 0)
+            {
+                transitionCanvasColor.gameObject.SetActive(false);
+                currentFadeInFadeOutTime = 0;
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
Overview:
- Added a canvas labelled transition canvas to the game state manager canvases
- Added logic in view manager to handle the fade in and out for the puzzles

Details:
- In view manager I added variables - fadePuzzleTransition to toggle fade in and out - transitionCanvasColor holds the color of the transition panel - fadeInFadeOutInBetween and currentFadeInFadeOutTime are timer variables for max and current time

- changed where the puzzleSwitch action is invoked to instead trigger the fade to black in FixedUpdate
- in between fade to black and the fade back to the game puzzleSwitch is invoked to transition behind the scenes
- After the fade back in to the game the canvas is disabled to prevent any raycast registration bugs