### PR TITLE
Fixed #645 | Fade In and Out During Puzzle Reset

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/UI/PuzzleCanvas.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/UI/PuzzleCanvas.prefab
@@ -1,5 +1,80 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &257140842075450758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4298077058644541058}
+  - component: {fileID: 449475774807034953}
+  - component: {fileID: 7027326121144440323}
+  m_Layer: 5
+  m_Name: ResetCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4298077058644541058
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 257140842075450758}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 19.463, y: 10.799, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8794074883102573080}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &449475774807034953
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 257140842075450758}
+  m_CullTransparentMesh: 1
+--- !u!114 &7027326121144440323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 257140842075450758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &296516117294404677
 GameObject:
   m_ObjectHideFlags: 0
@@ -894,6 +969,7 @@ RectTransform:
   - {fileID: 9041151082667156760}
   - {fileID: 3442450792248697701}
   - {fileID: 8154583104483929888}
+  - {fileID: 4298077058644541058}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1109,6 +1185,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cd39a59ad73f0c943a52339e623df879, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::ResetPuzzle
+  resetCanvasColor: {fileID: 7027326121144440323}
+  fadeInFadeOutInBetween: 0.5
+  currentFadeInFadeOutTime: 0
 --- !u!1001 &3550467319976446435
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1255,7 +1334,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSize
-      value: 72
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSizeBase
@@ -1401,7 +1480,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSize
-      value: 72
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSizeBase
@@ -1555,7 +1634,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSize
-      value: 72
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSizeBase
@@ -1721,7 +1800,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSize
-      value: 72
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 4846095183904175599, guid: b2467d0f5cc7a224ca285f266f255307, type: 3}
       propertyPath: m_fontSizeBase

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/ResetPuzzle.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/ResetPuzzle.cs
@@ -1,16 +1,78 @@
 using System;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.UI;
 
 public class ResetPuzzle : MonoBehaviour
 {
 
     public static event Action resetPuzzle;
 
+    public static bool fadePuzzleTransition = false;
+    public Image resetCanvasColor;
+    public float fadeInFadeOutInBetween = 0.5f;
+    public float currentFadeInFadeOutTime = 0f;
 
     public static void OnReset()
     {
         Debug.Log("Resetting Puzzle");
-        resetPuzzle.Invoke();
+        fadePuzzleTransition = true;
     }
+
+    private void FixedUpdate()
+    {
+
+        if (fadePuzzleTransition)
+        {
+            //transitionCanvasColor = GameObject.Find("TransitionCanvas").GetComponent<Image>();
+            resetCanvasColor.gameObject.SetActive(true);
+
+            if (resetCanvasColor != null && resetCanvasColor.color.a < 1)
+            {
+                Color newColor = resetCanvasColor.color;
+
+                newColor.a = newColor.a + Time.deltaTime;
+
+                resetCanvasColor.color = newColor; //fade in over time
+
+            }
+            else
+            {
+                //timer in between fade in and out to give some visual rest
+                if (currentFadeInFadeOutTime < fadeInFadeOutInBetween)
+                {
+                    currentFadeInFadeOutTime += Time.deltaTime;
+                }
+                else
+                {
+                    fadePuzzleTransition = false;
+                    // Notify GameStateManager that we've detected a puzzle switch.
+                    resetPuzzle.Invoke();
+                }
+
+            }
+
+        }
+        else
+        {
+
+            if (resetCanvasColor != null && resetCanvasColor.color.a >= 0)
+            {
+
+                Color newColor = resetCanvasColor.color;
+
+                newColor.a = newColor.a - Time.deltaTime;
+
+                resetCanvasColor.color = newColor; //fade out over time
+
+            }
+            else if (resetCanvasColor != null && resetCanvasColor.gameObject.activeInHierarchy && resetCanvasColor.color.a <= 0)
+            {
+                resetCanvasColor.gameObject.SetActive(false);
+                currentFadeInFadeOutTime = 0;
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
Overview:
- placed the system created in #703 into the reset puzzle script
- used resetPuzzle.Invoke instead to trigger the puzzle reset in the middle of the fade transition