### PR TITLE
Fixed #706 | Puzzle Cheat System Works with New Developer Shortcut

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -4,7 +4,14 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="" />
+    <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Prefabs/Player/Player.prefab" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Prefabs/Player/Player.prefab" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Ice_Island.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Interaction/InteractableCrystal.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Interaction/InteractableCrystal.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerControls.inputactions" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerControls.inputactions" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerControlsInputs.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerControlsInputs.cs" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -58,7 +65,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "issue/681-broken-puzzles-after-v2.3.0",
+    "git-widget-placeholder": "issue/706-cheat-sign-for-final-release",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }
@@ -94,7 +101,7 @@
       <option name="MIXED_MODE_DEBUG" value="0" />
       <method v="2" />
     </configuration>
-    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost">
+    <configuration name="Attach to Unity Editor" type="UNITY_DEBUG_RUN_CONFIGURATION" factoryName="Unity Debug" show_console_on_std_err="false" show_console_on_std_out="false" port="50000" address="localhost" useMixedMode="false">
       <option name="allowRunningInParallel" value="false" />
       <option name="listenPortForConnections" value="false" />
       <option name="pid" />
@@ -105,7 +112,6 @@
       <option name="selectedOptions">
         <list />
       </option>
-      <option name="useMixedMode" value="false" />
       <method v="2" />
     </configuration>
     <configuration name="Attach to" type="UnityDevicePlayer" factoryName="UnityAttachToDevicePlayer">
@@ -122,6 +128,7 @@
       <workItem from="1777145649271" duration="2672000" />
       <workItem from="1778197320533" duration="1927000" />
       <workItem from="1778272602642" duration="3152000" />
+      <workItem from="1778536077536" duration="680000" />
     </task>
     <servers />
   </component>

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Player/Player.prefab
@@ -113,11 +113,7 @@ MonoBehaviour:
   charController: {fileID: 2122942772023879459}
   moveSpeed: 5
   sprintSpeed: 7
-  RotationSmoothTime: 0.12
   turnSpeed: 120
-  jumpPower: 4
-  maxJumps: 1
-  jumpsRemaining: 0
   JumpHeight: 1.2
   Gravity: -15
   isGrounded: 0
@@ -156,6 +152,9 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+  maxTime: 0.5
+  currTime: 0
+  runTimer: 0
 --- !u!114 &6739596773503058293
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -546,7 +545,19 @@ MonoBehaviour:
     m_ActionId: 5d6c1e9f-b067-423b-86d8-bba0b5b8b0c9
     m_ActionName: 'Puzzle/Navigate[/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]'
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6211892080048543029}
+        m_TargetAssemblyTypeName: PlayerControlsInputs, Assembly-CSharp
+        m_MethodName: DevShortcutTriggered
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: db106398-fb81-4813-aa82-32b1cfa8ffec
     m_ActionName: 'Puzzle/Cancel[/Keyboard/l]'
   - m_PersistentCalls:
@@ -617,6 +628,22 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: 4d3d3456-9e44-43f8-8754-4f9ab377d117
     m_ActionName: 'Puzzle/PuzzleReset[/Keyboard/r]'
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6211892080048543029}
+        m_TargetAssemblyTypeName: PlayerControlsInputs, Assembly-CSharp
+        m_MethodName: DevShortcutTriggered
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 1694367b-9415-45f5-8579-c9feb700c32b
+    m_ActionName: 'Player/DevShortcut[/Keyboard/9,/Keyboard/numpad9]'
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard&Mouse
   m_DefaultActionMap: Player

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Flower_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Flower_Island.unity
@@ -442,6 +442,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 3
+  slideTile: 0
   gridManager: {fileID: 1351292436}
   selectableTilesParent: {fileID: 1351292435}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -875,6 +876,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 2
   gridZ: 6
+  slideTile: 0
   gridManager: {fileID: 1351292436}
   selectableTilesParent: {fileID: 1351292435}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -1179,15 +1181,15 @@ PrefabInstance:
       objectReference: {fileID: 1766300490}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 25.19
+      value: 24.41
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.136
+      value: -17.82
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 27.12
+      value: 26.48
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3083,6 +3085,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 4
+  slideTile: 0
   gridManager: {fileID: 1351292436}
   selectableTilesParent: {fileID: 1351292435}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -3260,6 +3263,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 1
   gridZ: 4
+  slideTile: 0
   gridManager: {fileID: 1351292436}
   selectableTilesParent: {fileID: 1351292435}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -3936,7 +3940,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.size
-      value: 43
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[29].m_ActionId
@@ -3995,6 +3999,10 @@ PrefabInstance:
       value: 4d3d3456-9e44-43f8-8754-4f9ab377d117
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[43].m_ActionId
+      value: 1694367b-9415-45f5-8579-c9feb700c32b
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[29].m_ActionName
       value: 'Puzzle/Submit[/Keyboard/enter]'
       objectReference: {fileID: 0}
@@ -4049,6 +4057,10 @@ PrefabInstance:
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[42].m_ActionName
       value: 'Puzzle/PuzzleReset[/Keyboard/r]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[43].m_ActionName
+      value: 'Player/DevShortcut[/Keyboard/9,/Keyboard/numpad9]'
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[42].m_PersistentCalls.m_Calls.Array.size

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -1659,7 +1659,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.size
-      value: 43
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[29].m_ActionId
@@ -1718,6 +1718,10 @@ PrefabInstance:
       value: 4d3d3456-9e44-43f8-8754-4f9ab377d117
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[43].m_ActionId
+      value: 1694367b-9415-45f5-8579-c9feb700c32b
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[29].m_ActionName
       value: 'Puzzle/Submit[/Keyboard/enter]'
       objectReference: {fileID: 0}
@@ -1772,6 +1776,10 @@ PrefabInstance:
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[42].m_ActionName
       value: 'Puzzle/PuzzleReset[/Keyboard/r]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[43].m_ActionName
+      value: 'Player/DevShortcut[/Keyboard/9]'
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[32].m_PersistentCalls.m_Calls.Array.size
@@ -113624,15 +113632,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 18.34
+      value: 29.74
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.892
+      value: -69.8
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -12.67
+      value: 1.97
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalRotation.w

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
@@ -1263,74 +1263,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00e95b7be7f041b0bdbcaa73cbb80815, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Airship
---- !u!1001 &314110038
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1045020396733171722, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_Name
-      value: PuzzleCheatSign (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 5785528264533770188, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: collectableCrystal
-      value: 
-      objectReference: {fileID: 1921092246}
-    - target: {fileID: 5785528264533770188, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: islandPuzzleManager
-      value: 
-      objectReference: {fileID: 1819275098}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 53.19
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.94
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 118.68
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: -0.8568755
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.5155235
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -62.065
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 8966030265941660681, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 0}
-  m_SourcePrefab: {fileID: 100100000, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
 --- !u!1001 &459277672
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4739,10 +4671,6 @@ PrefabInstance:
       propertyPath: m_ActionEvents.Array.data[33].m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 238665718}
-    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
-      propertyPath: m_ActionEvents.Array.data[33].m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: LeftClickDetected
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -5076,7 +5004,6 @@ SceneRoots:
   - {fileID: 1021214702}
   - {fileID: 1921092245}
   - {fileID: 683246938}
-  - {fileID: 314110038}
   - {fileID: 935159804}
   - {fileID: 238665716}
   - {fileID: 459277672}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -25122,7 +25122,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.892
+      value: -32
       objectReference: {fileID: 0}
     - target: {fileID: 6396842623713357803, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
       propertyPath: m_LocalPosition.z
@@ -33008,7 +33008,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.size
-      value: 43
+      value: 44
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[29].m_ActionId
@@ -33067,6 +33067,10 @@ PrefabInstance:
       value: 4d3d3456-9e44-43f8-8754-4f9ab377d117
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[43].m_ActionId
+      value: 1694367b-9415-45f5-8579-c9feb700c32b
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[29].m_ActionName
       value: 'Puzzle/Submit[/Keyboard/enter]'
       objectReference: {fileID: 0}
@@ -33121,6 +33125,10 @@ PrefabInstance:
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[42].m_ActionName
       value: 'Puzzle/PuzzleReset[/Keyboard/r]'
+      objectReference: {fileID: 0}
+    - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
+      propertyPath: m_ActionEvents.Array.data[43].m_ActionName
+      value: 'Player/DevShortcut[/Keyboard/9,/Keyboard/numpad9]'
       objectReference: {fileID: 0}
     - target: {fileID: 6922169669516928053, guid: 54c3cae06d7e2984c907b8af2732c354, type: 3}
       propertyPath: m_ActionEvents.Array.data[42].m_PersistentCalls.m_Calls.Array.size

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/InteractableCrystal.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Interaction/InteractableCrystal.cs
@@ -26,7 +26,7 @@ public class InteractableCrystal : MonoBehaviour, IInteractable
     private void FixedUpdate()
     {
 
-        Debug.Log("Height: " + transform.position.y);
+        // Debug.Log("Height: " + transform.position.y);
 
         if (transform.position.y >= maxHeight)
         {

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControls.inputactions
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControls.inputactions
@@ -104,6 +104,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "DevShortcut",
+                    "type": "Button",
+                    "id": "1694367b-9415-45f5-8579-c9feb700c32b",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -555,6 +564,28 @@
                     "processors": "",
                     "groups": ";Keyboard&Mouse",
                     "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e50461f5-f6b4-4236-bbf8-e693ae5da8f1",
+                    "path": "<Keyboard>/9",
+                    "interactions": "MultiTap",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "DevShortcut",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "83ed50e8-73e9-44b3-8258-9ae0660ea484",
+                    "path": "<Keyboard>/numpad9",
+                    "interactions": "MultiTap",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "DevShortcut",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -10,6 +11,7 @@ public class PlayerControlsInputs : MonoBehaviour
 	public Vector2 look;
 	public bool jump;
 	public bool sprint;
+	public static event Action devShortcutTriggered;
 
 	/// <summary>
 	/// Takes the player's keyboard input in context as a Vector2 and
@@ -73,6 +75,19 @@ public class PlayerControlsInputs : MonoBehaviour
 		{
 			jump = false;
 			Debug.Log("PlayerControlsInputs.cs >> Jump canceled.");
+		}
+	}
+	
+	public void DevShortcutTriggered(InputAction.CallbackContext context)
+	{
+		if (context.performed)
+		{
+			devShortcutTriggered?.Invoke();
+			Debug.Log("PlayerControlsInputs.cs >> devShortcut performed.");
+		}
+		else if (context.canceled)
+		{
+			Debug.Log("PlayerControlsInputs.cs >> devShortcut canceled.");
 		}
 	}
 }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/World/PuzzleCheatSign.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/World/PuzzleCheatSign.cs
@@ -15,6 +15,17 @@ public class PuzzleCheatSign : MonoBehaviour, IInteractable
     
     public static event Action allPuzzlesComplete;
 
+    private void OnEnable()
+    {
+        PlayerControlsInputs.devShortcutTriggered  += Interaction;
+    }
+
+    private void OnDisable()
+    {
+        PlayerControlsInputs.devShortcutTriggered  -= Interaction;
+    }
+    
+
     private void Awake()
     {
         // Get the puzzle prefabs


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`issue/706-cheat-sign-for-final-release`](https://github.com/Precipice-Games/untitled-26/tree/issue/706-cheat-sign-for-final-release) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR fixes #706.

### In-depth Details
- The puzzle cheat signs are all technically still on their respective islands.
- However, I moved all (but one) of them out of view of the Player.
     - This would be the cheat sign on the interior of the Mother Island, since I want to get @cassdaw's opinion on how that should be configured for the Player getting back to the top of the island.
- The Player must now double tap the number 9 on their keyboard to activate the same functionalities.