### PR TITLE
Fixed #728 | credits soundtrack

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Audio/Music/Credits_Track.mp3.meta
+++ b/00 Unity Proj/Untitled-26/Assets/Audio/Music/Credits_Track.mp3.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: 58dc229e0f6fc4a39804f59f6c056188
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 8
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/MainMenu.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/MainMenu.unity
@@ -678,6 +678,7 @@ MonoBehaviour:
   oasisIslandPuzzleTrack: {fileID: 0}
   iceIslandPuzzleTrack: {fileID: 8300000, guid: 61bc7a410ba3849d1a2eb2f44752f2c7, type: 3}
   flowerIslandPuzzleTrack: {fileID: 8300000, guid: 2f78499ac84f14eaa9aa07d3d3d3a3e5, type: 3}
+  creditsTrack: {fileID: 8300000, guid: 58dc229e0f6fc4a39804f59f6c056188, type: 3}
   fadeDuration: 1.05
   defaultVolume: 0.6
 --- !u!82 &816375123

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Audio/MusicManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Audio/MusicManager.cs
@@ -22,6 +22,9 @@ public class MusicManager : MonoBehaviour
     [SerializeField] private AudioClip iceIslandPuzzleTrack;
     [SerializeField] private AudioClip flowerIslandPuzzleTrack;
 
+    [Header("Credits Track")]
+    [SerializeField] private AudioClip creditsTrack;
+
     [Header("Settings")]
     [SerializeField] private float fadeDuration = 0.75f;
     [SerializeField] private float defaultVolume = 0.6f;
@@ -138,6 +141,10 @@ public class MusicManager : MonoBehaviour
             case "Flower_Island":
                 currentSceneTrack = flowerIslandTrack;
                 currentPuzzleTrack = flowerIslandPuzzleTrack;
+                break;
+
+            case "Credits":
+                currentSceneTrack = creditsTrack;
                 break;
         }
     }


### PR DESCRIPTION
### Overview
- Pulling the latest version of the branch for #728 into dev
- This PR closes the issue

### In-depth Details
- Updated MusicManager.cs to include the field and case for playing the credits soundtrack
- Added an unused soundtrack that Josh made to play when the credits roll