### PR TITLE
Hotfix | Fixed the Mana Tiles

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -6,9 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Mother_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Mother_Island.unity" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/ProjectSettings/EditorBuildSettings.asset" beforeDir="false" afterPath="$PROJECT_DIR$/ProjectSettings/EditorBuildSettings.asset" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/GridManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/GridManager.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -63,7 +62,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "#710 on issue/450-implement-puzzles-for-f…sland",
+    "git-widget-placeholder": "hotfix/fixed-mana-tile",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -485,20 +485,20 @@ public class PlayerFixedMovement : MonoBehaviour
 
             Debug.Log("PlayerFixedMovement.cs >> Player stepped on ManaWell! +2 Mana");
 
-            // if (gridManager.GetTile(coordX, coordZ).GetComponentInChildren<ParticleSystem>() != null)
-            // {
-            //
-            //     gridManager.GetTile(coordX, coordZ).GetComponentInChildren<ParticleSystem>().Stop();
-            //     gridManager.GetTile(coordX, coordZ).GetComponentInChildren<ParticleSystem>().Clear();
-            //
-            // }
-            //
-            // gridManager.GetTile(coordX, coordZ).GetComponent<MeshRenderer>().material = gridManager.GetTile(coordX, coordZ).GetComponent<OasisTexturing>().oasisNormalTexture;
-            //
-            // if (resourceManager != null)
-            // {
-            //     resourceManager.AddMana(2);
-            // }
+            if (gridManager.GetTile(coordX, coordZ).GetComponentInChildren<ParticleSystem>() != null)
+            {
+            
+                gridManager.GetTile(coordX, coordZ).GetComponentInChildren<ParticleSystem>().Stop();
+                gridManager.GetTile(coordX, coordZ).GetComponentInChildren<ParticleSystem>().Clear();
+            
+            }
+            
+            gridManager.GetTile(coordX, coordZ).GetComponent<MeshRenderer>().material = gridManager.GetTile(coordX, coordZ).GetComponent<OasisTexturing>().oasisNormalTexture;
+            
+            if (resourceManager != null)
+            {
+                resourceManager.AddMana(2);
+            }
         }
     }
 

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/GridManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Mechanics/GridManager.cs
@@ -200,23 +200,25 @@ public class GridManager : MonoBehaviour
             }
         }
     }
+    
+    
     public void ApplyGusts()
-{
-    for (int x = 0; x < width; x++)
     {
-        for (int z = 0; z < height; z++)
+        for (int x = 0; x < width; x++)
         {
-            if (grid[x, z] == null) continue;
-
-            SelectableTile tile = grid[x, z];
-
-            if (tile.tileType == SelectableTile.TileType.Gust)
+            for (int z = 0; z < height; z++)
             {
-                ApplySingleGust(tile);
+                if (grid[x, z] == null) continue;
+
+                SelectableTile tile = grid[x, z];
+
+                if (tile.tileType == SelectableTile.TileType.Gust)
+                {
+                    ApplySingleGust(tile);
+                }
             }
         }
     }
-}
 
 private void ApplySingleGust(SelectableTile gustTile)
 {
@@ -254,36 +256,41 @@ private void ApplySingleGust(SelectableTile gustTile)
     }
 }
 
-private void PushTile(SelectableTile tile, int dirX, int dirZ)
-{
-    int nextX = tile.gridX + dirX;
-    int nextZ = tile.gridZ + dirZ;
-
-    // keep pushing until blocked
-    while (IsInsideGrid(nextX, nextZ) && IsCellEmpty(nextX, nextZ))
+    private void PushTile(SelectableTile tile, int dirX, int dirZ)
     {
-        ClearCell(tile.gridX, tile.gridZ);
+        int nextX = tile.gridX + dirX;
+        int nextZ = tile.gridZ + dirZ;
 
-        tile.gridX = nextX;
-        tile.gridZ = nextZ;
-
-        PlaceTile(tile, tile.gridX, tile.gridZ);
-        tile.transform.localPosition = GridToWorld(tile.gridX, tile.gridZ);
-
-        nextX += dirX;
-        nextZ += dirZ;
-    }
-}
-    public bool IsBlockedCell(int x, int z)
-{
-    foreach (Vector2Int blocked in blockedCells)
-    {
-        if (blocked.x == x && blocked.y == z)
+        // keep pushing until blocked
+        while (IsInsideGrid(nextX, nextZ) && IsCellEmpty(nextX, nextZ))
         {
-            return true;
+            ClearCell(tile.gridX, tile.gridZ);
+
+            tile.gridX = nextX;
+            tile.gridZ = nextZ;
+
+            PlaceTile(tile, tile.gridX, tile.gridZ);
+            tile.transform.localPosition = GridToWorld(tile.gridX, tile.gridZ);
+
+            nextX += dirX;
+            nextZ += dirZ;
         }
     }
+    public bool IsBlockedCell(int x, int z)
+    {
+        foreach (Vector2Int blocked in blockedCells)
+        {
+            if (blocked.x == x && blocked.y == z)
+            {
+                return true;
+            }
+        }
 
-    return false;
-}
+        return false;
+    }
+    
+    public SelectableTile GetTile(int gridX, int gridZ)
+    {
+        return grid[gridX,gridZ];
+    }
 }


### PR DESCRIPTION
### Overview
- Pulling the latest version of [`hotfix/fixed-mana-tile`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/fixed-mana-tile) into [`dev`](https://github.com/Precipice-Games/untitled-26/tree/dev).
- This PR introduces a hotfix to the puzzle system.

### In-depth Details
- Figured out what was stopping the Mana system from working.
- It was working on the backend just fine, it was just that the onscreen text was not updating.
- Also restored an old method from GridManager.cs.