### PR TITLE
Fixed #559 | fix skys jumping animation

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Art/Animations/Scripts/Texture_Animation.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Animations/Scripts/Texture_Animation.cs
@@ -11,6 +11,11 @@ public class Texture_Animation : MonoBehaviour
     private float _frameCounter = 0.0f;
 
     [SerializeField]
+    private float lastVelocity;
+    [SerializeField]
+    private float currentVelocity;
+
+    [SerializeField]
     private Sprite[] _idleSprites = new Sprite[23];
     [SerializeField]
     private Sprite[] _runningSprites = new Sprite[27];
@@ -18,6 +23,8 @@ public class Texture_Animation : MonoBehaviour
     public bool _isRunning = false;
     [SerializeField]
     private Sprite[] _jumpingSprites = new Sprite[19];
+    [SerializeField]
+    public bool _isJumpingPerformed = false;
     [SerializeField]
     private bool _isJumping = false;
 
@@ -40,6 +47,9 @@ public class Texture_Animation : MonoBehaviour
     void FixedUpdate()
     {
 
+        lastVelocity = currentVelocity;
+        currentVelocity = transform.parent.GetComponent<CharacterController>().velocity.y;
+
         // Debug.Log(transform.parent.GetComponent<CharacterController>().velocity);
 
         // Debug.Log(transform.parent.GetComponent<CharacterController>().velocity);
@@ -54,12 +64,11 @@ public class Texture_Animation : MonoBehaviour
         {
             _isRunning = false;
         }
-
-        if (Math.Abs(transform.parent.GetComponent<CharacterController>().velocity.y) >= 1.75)
+        if (_isJumpingPerformed && lastVelocity > 0)
         {
             _isJumping = true;
         }
-        else
+        else if (_isJumping && lastVelocity < 0 && transform.parent.GetComponent<CharacterController>().velocity.y == 0f)
         {
             _isJumping = false;
         }

--- a/00 Unity Proj/Untitled-26/Assets/Art/Animations/Scripts/Texture_Animation.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Animations/Scripts/Texture_Animation.cs
@@ -11,9 +11,9 @@ public class Texture_Animation : MonoBehaviour
     private float _frameCounter = 0.0f;
 
     [SerializeField]
-    private float lastVelocity;
+    private float lastYVelocity;
     [SerializeField]
-    private float currentVelocity;
+    private float currentYVelocity;
 
     [SerializeField]
     private Sprite[] _idleSprites = new Sprite[23];
@@ -47,12 +47,12 @@ public class Texture_Animation : MonoBehaviour
     void FixedUpdate()
     {
 
-        lastVelocity = currentVelocity;
-        currentVelocity = transform.parent.GetComponent<CharacterController>().velocity.y;
+        lastYVelocity = currentYVelocity;
+        currentYVelocity = transform.parent.GetComponent<CharacterController>().velocity.y;
 
-        // Debug.Log(transform.parent.GetComponent<CharacterController>().velocity);
+        Debug.Log("LAST Y VELO" + lastYVelocity);
 
-        // Debug.Log(transform.parent.GetComponent<CharacterController>().velocity);
+        Debug.Log("CURRENT Y VELO" + currentYVelocity);
 
         if (transform.parent.GetComponent<CharacterController>().velocity.x != 0 || transform.parent.GetComponent<CharacterController>().velocity.z != 0)
         {
@@ -64,11 +64,11 @@ public class Texture_Animation : MonoBehaviour
         {
             _isRunning = false;
         }
-        if (_isJumpingPerformed && lastVelocity > 0)
+        if (_isJumpingPerformed && lastYVelocity > 0)
         {
             _isJumping = true;
         }
-        else if (_isJumping && lastVelocity < 0 && transform.parent.GetComponent<CharacterController>().velocity.y == 0f)
+        else if (transform.parent.GetComponent<PlayerGroundcast>().GetOnGrounded())
         {
             _isJumping = false;
         }

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
@@ -69,6 +69,7 @@ public class PlayerControlsInputs : MonoBehaviour
 		if (context.performed)
 		{
 			jump = true;
+			gameObject.GetComponentInChildren<Texture_Animation>()._isJumpingPerformed = true;
 			Debug.Log("PlayerControlsInputs.cs >> Jump performed.");
 		}
 		else if (context.canceled)

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerControlsInputs.cs
@@ -75,6 +75,7 @@ public class PlayerControlsInputs : MonoBehaviour
 		else if (context.canceled)
 		{
 			jump = false;
+			gameObject.GetComponentInChildren<Texture_Animation>()._isJumpingPerformed = false;
 			Debug.Log("PlayerControlsInputs.cs >> Jump canceled.");
 		}
 	}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerGroundcast.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerGroundcast.cs
@@ -153,4 +153,10 @@ public class PlayerGroundcast : MonoBehaviour
             groundcastHitInteractable?.Invoke(true);
         }
     }
+
+    public bool GetOnGrounded()
+    {
+        return onGround;
+    }
+
 }


### PR DESCRIPTION
Overview:
- Added Logic to PlayerControlsInputs to trigger performed variables in texture animation when the jump input is pressed
- Added Logic to Texture Animations that handles the jump performed from PlayerControlsInputs and tracking lastYVelocity to register when the player is in the air
     - Added a GetOnGrounded() to check if the player is on the ground and stops the jumping animation