### PR TITLE
Hotfix | Restored Puzzle Dialogue Triggers

### DIFF
--- a/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
+++ b/00 Unity Proj/Untitled-26/.idea/.idea.Untitled-26/.idea/workspace.xml
@@ -4,7 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="" />
+    <list default="true" id="fbef25c7-7cea-4452-bcf0-670b2112a0f8" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.Untitled-26/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Art/Animations/Scripts/Texture_Animation.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Art/Animations/Scripts/Texture_Animation.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scenes/Islands/Mother_Island.unity" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scenes/Islands/Mother_Island.unity" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -36,8 +42,15 @@
   <component name="HighlightingSettingsPerFile">
     <setting file="file://$PROJECT_DIR$/Assets/Prefabs/Puzzles/IceBasePuzzle.prefab" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Prefabs/UI/PuzzleCanvas.prefab" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Game States/GameManager.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Interaction/InteractableDoor.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/Misc/DevBuildGameObject.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Player/PlayerFixedMovement.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Puzzles/Data/ResourceManager.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/GridManager.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTile.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/SelectableTilesParent.cs" root0="FORCE_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Assets/Scripts/Puzzles/Mechanics/TileSelector.cs" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.cdm.figma.ui@dd99ee4699bf/Runtime/Styles/CanvasGroupStyleSetter.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.cdm.figma.ui@dd99ee4699bf/Runtime/Styles/ImageStyleSetter.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.cdm.figma.ui@dd99ee4699bf/Runtime/Styles/StyleSetterWithSelectors.cs" root0="SKIP_HIGHLIGHTING" />
@@ -58,7 +71,7 @@
     "RunOnceActivity.git.unshallow": "true",
     "RunOnceActivity.typescript.service.memoryLimit.init": "true",
     "Standalone Player.Start Unity.executor": "Run",
-    "git-widget-placeholder": "hotfix/implement-mother-crystal-sprite",
+    "git-widget-placeholder": "#750 on hotfix/post-tutorial-puzzle-dialogue",
     "nodejs_package_manager_path": "npm",
     "vue.rearranger.settings.migration": "true"
   }
@@ -123,6 +136,7 @@
       <workItem from="1778197320533" duration="1927000" />
       <workItem from="1778272602642" duration="3152000" />
       <workItem from="1778536077536" duration="680000" />
+      <workItem from="1778693468820" duration="2316000" />
     </task>
     <servers />
   </component>

--- a/00 Unity Proj/Untitled-26/Assets/Art/Animations/Scripts/Texture_Animation.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Art/Animations/Scripts/Texture_Animation.cs
@@ -50,9 +50,9 @@ public class Texture_Animation : MonoBehaviour
         lastYVelocity = currentYVelocity;
         currentYVelocity = transform.parent.GetComponent<CharacterController>().velocity.y;
 
-        Debug.Log("LAST Y VELO" + lastYVelocity);
+        // Debug.Log("LAST Y VELO" + lastYVelocity);
 
-        Debug.Log("CURRENT Y VELO" + currentYVelocity);
+        // Debug.Log("CURRENT Y VELO" + currentYVelocity);
 
         if (transform.parent.GetComponent<CharacterController>().velocity.x != 0 || transform.parent.GetComponent<CharacterController>().velocity.z != 0)
         {

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/MotherIsland.yarn
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/MotherIsland.yarn
@@ -100,7 +100,6 @@ Cumulus: And if you feel called… you should go see her.” #line:0757bfa
 Cumulus: Back so soon, kiddo? You look like you’ve seen a hurricane.
 
 Sky: Dad! You were right! Mother Crystal really did call me! She gave me her blessing!
-(Sky’s aura should light up here until the end of the interaction)
 
 Cumulus: So it’s time… 
 

--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/MotherIsland.yarn
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/MotherIsland.yarn
@@ -92,6 +92,8 @@ Cumulus: And if you feel called… you should go see her.” #line:0757bfa
 <<enableInvisWall CrystalCallWall>>
 <<endonce>>
 
+<b>Go to Mother Crystal</b>
+
 <<else>>
 <<once>>
 <<toggleExclamation Cumulus>>

--- a/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
+++ b/00 Unity Proj/Untitled-26/Assets/Prefabs/Puzzles/MotherBasePuzzle.prefab
@@ -158,6 +158,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 2
   gridZ: 3
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -335,6 +336,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 1
   gridZ: 1
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -425,6 +427,7 @@ MonoBehaviour:
   puzzleInfo: {fileID: 9191018659038673785}
   exitPuzzleButton: {fileID: 4943596135170749970}
   otherRuneCircle: {fileID: 3624906698350998147}
+  puzzleDialogue: {fileID: 0}
 --- !u!1 &925581002351369635
 GameObject:
   m_ObjectHideFlags: 0
@@ -583,6 +586,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 5
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -760,6 +764,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 1
   gridZ: 4
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -937,6 +942,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 1
   gridZ: 5
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -1027,6 +1033,7 @@ MonoBehaviour:
   puzzleInfo: {fileID: 9191018659038673785}
   exitPuzzleButton: {fileID: 4943596135170749970}
   otherRuneCircle: {fileID: 7321162161942524934}
+  puzzleDialogue: {fileID: 5078768778106471089}
 --- !u!1 &2065247099526973384
 GameObject:
   m_ObjectHideFlags: 0
@@ -1185,6 +1192,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 2
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -1362,6 +1370,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 5
   gridZ: 3
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -1540,6 +1549,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 1
   gridZ: 6
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -1718,6 +1728,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 0
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -1895,6 +1906,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 2
   gridZ: 2
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -2050,6 +2062,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 14eb0a16258e2034d9bb137e1435805f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::GridManager
+  blockedCells: []
   width: 13
   height: 13
   tileSize: 3
@@ -2212,6 +2225,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 4
   gridZ: 4
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -2389,6 +2403,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 4
   gridZ: 2
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -2566,6 +2581,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 1
   gridZ: 3
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -2743,6 +2759,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 3
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}
@@ -3102,6 +3119,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 4
   gridZ: 1
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -3131,6 +3149,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3397337548393501967}
   - component: {fileID: 9191018659038673785}
+  - component: {fileID: 5078768778106471089}
   m_Layer: 0
   m_Name: MotherBasePuzzle
   m_TagString: Untagged
@@ -3177,6 +3196,22 @@ MonoBehaviour:
   gridManager: {fileID: 4785314922009797101}
   resourceManager: {fileID: 7600570827429529725}
   puzzleSolved: 0
+--- !u!114 &5078768778106471089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7199852587322879966}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cdfff3539f15de84b9e1ff3ac3c6b839, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PuzzleDialogueTrigger
+  runner: {fileID: 0}
+  enterNode: 
+  exitNode: 
+  exitDelay: 0.5
 --- !u!1 &7264184287714543087
 GameObject:
   m_ObjectHideFlags: 0
@@ -3411,6 +3446,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 3
   gridZ: 1
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 4712742159807781497}
   originalColor: {r: 1, g: 1, b: 1, a: 1}
@@ -3503,6 +3539,9 @@ MonoBehaviour:
   printManaDeductions: 1
   printCardDeductions: 1
   printCardDrainage: 1
+  flashOutOfMana: 0
+  maxflashDelay: 0.4
+  currentFlashDelay: 0
 --- !u!1 &8066876773405094797
 GameObject:
   m_ObjectHideFlags: 0
@@ -3661,6 +3700,7 @@ MonoBehaviour:
   gustDirection: 0
   gridX: 5
   gridZ: 2
+  slideTile: 0
   gridManager: {fileID: 1640623606830934790}
   selectableTilesParent: {fileID: 0}
   originalColor: {r: 1, g: 0, b: 1, a: 1}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
@@ -2854,6 +2854,8 @@ Transform:
   m_Children:
   - {fileID: 1217507562}
   - {fileID: 1527132438}
+  - {fileID: 1351820808}
+  - {fileID: 1043708401}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &164577195
@@ -16627,6 +16629,18 @@ PrefabInstance:
       propertyPath: gridX
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 5078768778106471089, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: runner
+      value: 
+      objectReference: {fileID: 1401920747}
+    - target: {fileID: 5078768778106471089, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: exitNode
+      value: postPuzzle2Dialogue
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078768778106471089, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: enterNode
+      value: tutorialPuzzle2Dialogue
+      objectReference: {fileID: 0}
     - target: {fileID: 6241378083209524425, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 9
@@ -17315,6 +17329,85 @@ Transform:
   - {fileID: 902199260}
   m_Father: {fileID: 384952038}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1043708400
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 162628310}
+    m_Modifications:
+    - target: {fileID: 284139327139716902, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_Name
+      value: AirshipDialogueWall
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289083002470871479, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.98
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -59.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.11045088
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99388164
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -192.683
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5805634206812437526, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6827900128755941403, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: runner
+      value: 
+      objectReference: {fileID: 1401920747}
+    - target: {fileID: 6827900128755941403, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: nodeToRun
+      value: getSentOffDialogue
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 5805634206812437526, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+--- !u!4 &1043708401 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+  m_PrefabInstance: {fileID: 1043708400}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1048829107
 GameObject:
   m_ObjectHideFlags: 0
@@ -18539,6 +18632,18 @@ PrefabInstance:
     - target: {fileID: 5025002967551595757, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
       propertyPath: gridX
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078768778106471089, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: runner
+      value: 
+      objectReference: {fileID: 1401920747}
+    - target: {fileID: 5078768778106471089, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: exitNode
+      value: postPuzzle1Dialogue
+      objectReference: {fileID: 0}
+    - target: {fileID: 5078768778106471089, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
+      propertyPath: enterNode
+      value: tutorialPuzzle1Dialogue
       objectReference: {fileID: 0}
     - target: {fileID: 7032101937263023470, guid: 0487eeb8116a2bc44b04ac1dd8955b3d, type: 3}
       propertyPath: m_LocalPosition.x
@@ -21769,6 +21874,84 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 8014860526984270938, guid: 52fcc2c214e11dd46bc310e39123907a, type: 3}
   m_PrefabInstance: {fileID: 1315963245}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1351820807
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 162628310}
+    m_Modifications:
+    - target: {fileID: 284139327139716902, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_Name
+      value: AirshipColliderWall
+      objectReference: {fileID: 0}
+    - target: {fileID: 3289083002470871479, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.97
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -55.61
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.11045088
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.99388164
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -192.683
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5805634206812437526, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6827900128755941403, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: runner
+      value: 
+      objectReference: {fileID: 1401920747}
+    - target: {fileID: 6827900128755941403, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+      propertyPath: nodeToRun
+      value: needDadDialogue
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+--- !u!4 &1351820808 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3717115231324951926, guid: d47a7be5b1491e244bd31a7dd50aaa4d, type: 3}
+  m_PrefabInstance: {fileID: 1351820807}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1356831573
 PrefabInstance:

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Mother_Island.unity
@@ -15245,7 +15245,19 @@ MonoBehaviour:
   teleportLocation: {fileID: 532736204}
   doorEntered:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1290635322}
+        m_TargetAssemblyTypeName: InteractableCrystal, Assembly-CSharp
+        m_MethodName: Interaction
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   fadePuzzleTransition: 0
   transitionCanvasColor: {fileID: 304425527}
   fadeInFadeOutInBetween: 0.5

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
@@ -254,7 +254,7 @@ public class GameStateManager : MonoSingleton<GameStateManager>
     public void onPuzzleCompleted()
     {
         TransitionToState(GameState.Exploration);
-        SFXManager.Instance.PlayPuzzleComplete();
+        if(SFXManager.Instance != null) SFXManager.Instance.PlayPuzzleComplete();
     }
     
     /// <summary>

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -508,6 +508,11 @@ public class PlayerFixedMovement : MonoBehaviour
     /// </summary>
     private void IsPlayerOnEndTile()
     {
+        Debug.Log("PlayerFixedMovement.cs >> Checking if Player is on the end tile...");
+        Debug.Log($"PlayerFixedMovement.cs >> endTileX: {endTileX} | endTileZ: {endTileZ}");
+        Debug.Log($"PlayerFixedMovement.cs >> playerGridX: " + playerGridX + " | playerGridZ: " + playerGridZ);
+        
+        
         // Check if the Player's coordinates match the end tile's coordinates
         if (endTileX == playerGridX && endTileZ == playerGridZ)
         {

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs
@@ -36,6 +36,7 @@ public class IslandPuzzleManager : MonoBehaviour
         PuzzleDialogueTrigger dialogueTrigger = completedPuzzle.GetComponent<PuzzleDialogueTrigger>();
         if (dialogueTrigger != null)
         {
+            Debug.Log("Checkpoint reached");
             dialogueTrigger.OnPuzzleExit();
         }
         completedPuzzle.puzzleSolved = true;

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Puzzles/Data/IslandPuzzleManager.cs
@@ -50,20 +50,24 @@ public class IslandPuzzleManager : MonoBehaviour
     {
         foreach (GameObject puzzlePrefab in puzzlePrefabs)
         {
+            Debug.Log("IslandPuzzleManager.cs >> Checking puzzle: " + puzzlePrefab.name);
+            Debug.Log($"{puzzlePrefab.name} solved status: {puzzlePrefab.GetComponent<PuzzleInformation>().puzzleSolved}");
+            
             PuzzleInformation puzzleInfo = puzzlePrefab.GetComponent<PuzzleInformation>();
-
+            
             // Exit if there's any puzzles unsolved
             if (puzzleInfo.puzzleSolved == false)
             {
                 return;
             }
             
-            Debug.Log("IslandPuzzleManager.cs >> All puzzles completed!");
-            
-            // This event is assigned in the Unity Editor. It notifies
-            // the IslandManager and the InteractableCrystal that all
-            // puzzles have been completed.
-            islandPuzzlesCompleted.Invoke();
+            Debug.Log("IslandPuzzleManager.cs >> There's still more puzzles to complete.");
         }
+        
+        // This event is assigned in the Unity Editor. It notifies
+        // the IslandManager and the InteractableCrystal that all
+        // puzzles have been completed.
+        islandPuzzlesCompleted.Invoke();
+        Debug.Log("IslandPuzzleManager.cs >> All puzzles completed!");
     }
 }


### PR DESCRIPTION
Overview
- Pulling the latest version of [`hotfix/post-tutorial-puzzle-dialogue`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/post-tutorial-puzzle-dialogue) into [`main`](https://github.com/Precipice-Games/untitled-26)

Fixes These Bugs Found by @Tientuine 
- Interact prompt remains for Cumulus after first interaction but Sky but does nothing.
- Placeholder instructions appear in follow-up dialogue with Cumulus.. Sky's aura should light up here until the end of the interaction
- Sky is stuck and cannot move after completing follow-up dialogue with Cumulus.
- Missing any explanation/dialogue after completing tutorial and returning to the surface.

Fix: 
- Ensured mother island puzzles had puzzle dialogue trigger components that activate dialogue on puzzle enter and exit
- Restored Airship dialogue walls that were preventing progression and player movement