### PR TITLE
Hotfix | oasis island ending

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Dialogue/MotherIsland.yarn
+++ b/00 Unity Proj/Untitled-26/Assets/Dialogue/MotherIsland.yarn
@@ -110,7 +110,7 @@ Cumulus: Aha! You don’t even have to ask! After all, it’s my duty as your fa
 
 Sky: Aww Dad!...
 
-Cumulus - Climb aboard, Sky! You’ll reach the closest island if you follow the wind!
+Cumulus: Climb aboard, Sky! You’ll reach the closest island if you follow the wind!
 
 Cumulus: I hear this island is quite chilly. You’ll know you’re close when you begin to pass through the relentless frigid winds.
 

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -28616,8 +28616,8 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 63.18451, y: 4.232563, z: 111.936806}
-  m_Center: {x: -53.53543, y: 31.616304, z: 61.56982}
+  m_Size: {x: 63.18451, y: 4.96611, z: 111.936806}
+  m_Center: {x: -53.53543, y: 31.983078, z: 61.56982}
 --- !u!1001 &1304818189
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -35335,7 +35335,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   moveDirection: {x: 1, y: 0, z: 1}
   moveDistance: 15
-  speed: 8.57
+  speed: 7
   isActive: 0
   charController: {fileID: 0}
 --- !u!65 &1728649765
@@ -40981,7 +40981,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   moveDirection: {x: 1, y: 0, z: 1}
   moveDistance: 15
-  speed: 8
+  speed: 7.5
   isActive: 0
   charController: {fileID: 0}
 --- !u!65 &1783707276
@@ -42202,7 +42202,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: '::'
   moveDirection: {x: 1, y: 1, z: 1}
   moveDistance: 14.01
-  speed: 9
+  speed: 7
   isActive: 0
   charController: {fileID: 0}
 --- !u!65 &1982907263

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -27937,6 +27937,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3624906698350998147, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -13.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3624906698350998147, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/GameStateManager.cs
@@ -254,7 +254,7 @@ public class GameStateManager : MonoSingleton<GameStateManager>
     public void onPuzzleCompleted()
     {
         TransitionToState(GameState.Exploration);
-        SFXManager.Instance.PlayPuzzleComplete();
+        if(SFXManager.Instance != null) SFXManager.Instance.PlayPuzzleComplete();
     }
     
     /// <summary>

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -273,7 +273,11 @@ public class PlayerFixedMovement : MonoBehaviour
         // as though the Player is only traveling one tile. We want to ensure that first
         // tile is not empty and is within the bounds before doing anything else.
         if (CheckForOutOfBounds(attemptedDestX, attemptedDestZ)) return;
-        if (CheckForEmptyCell(attemptedDestX, attemptedDestZ)) SnapPlayerToTile(startTileX, startTileZ);
+        if (CheckForEmptyCell(attemptedDestX, attemptedDestZ))
+        {
+            SnapPlayerToTile(startTileX, startTileZ);
+            return;
+        }
 
         // If the move is valid, we've reached this part of the code.
         // Check what type of tile the Player is attempting to move to.


### PR DESCRIPTION
Overview
- Pulling the latest version of [`hotfix/oasis-island-ending`](https://github.com/Precipice-Games/untitled-26/tree/hotfix/oasis-island-ending) into [`main`](https://github.com/Precipice-Games/untitled-26)

In-Depth Details
- Added null reference checks for SFXManager and Tiles on puzzle failure that was preventing puzzles from being marked as completed
- Made parkour slightly easier & configured deathbox for parkour