### PR TITLE
Hotfix | Added Music to Ending Scene

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scenes/MainMenu.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/MainMenu.unity
@@ -674,6 +674,7 @@ MonoBehaviour:
   oasisIslandTrack: {fileID: 8300000, guid: ef15429dfb1874165ad7c46a252d7dc1, type: 3}
   iceIslandTrack: {fileID: 8300000, guid: c2762d05acb8843e88e7aeb8e3b4086d, type: 3}
   flowerIslandTrack: {fileID: 8300000, guid: f40f4c7e34c1546fdaa7a9e313803fc5, type: 3}
+  endingTrack: {fileID: 8300000, guid: 16423356ea11343ed9f88b09cca959dd, type: 3}
   motherIslandPuzzleTrack: {fileID: 8300000, guid: 8631798488cc64812800bb5bc4815413, type: 3}
   oasisIslandPuzzleTrack: {fileID: 0}
   iceIslandPuzzleTrack: {fileID: 8300000, guid: 61bc7a410ba3849d1a2eb2f44752f2c7, type: 3}
@@ -1575,7 +1576,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5813188273321872142, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -13
+      value: -12.9999695
       objectReference: {fileID: 0}
     - target: {fileID: 6019136434661588726, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -1703,7 +1704,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7804412830963627737, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -13
+      value: -12.9999695
       objectReference: {fileID: 0}
     - target: {fileID: 7830017286838153912, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: m_text

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Audio/MusicManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Audio/MusicManager.cs
@@ -15,7 +15,8 @@ public class MusicManager : MonoBehaviour
     [SerializeField] private AudioClip oasisIslandTrack;
     [SerializeField] private AudioClip iceIslandTrack;
     [SerializeField] private AudioClip flowerIslandTrack;
-
+    [SerializeField] private AudioClip endingTrack;
+ 
     [Header("Puzzle Track Per Scene")]
     [SerializeField] private AudioClip motherIslandPuzzleTrack;
     [SerializeField] private AudioClip oasisIslandPuzzleTrack;
@@ -141,6 +142,10 @@ public class MusicManager : MonoBehaviour
             case "Flower_Island":
                 currentSceneTrack = flowerIslandTrack;
                 currentPuzzleTrack = flowerIslandPuzzleTrack;
+                break;
+
+            case "Ending":
+                currentSceneTrack = endingTrack;
                 break;
 
             case "Credits":

--- a/00 Unity Proj/Untitled-26/Assets/Settings/Build Profiles/Windows.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Settings/Build Profiles/Windows.asset
@@ -33,6 +33,8 @@ MonoBehaviour:
   - m_enabled: 1
     m_path: Assets/Scenes/Islands/Flower_Island.unity
   - m_enabled: 1
+    m_path: Assets/Scenes/Islands/Ending.unity
+  - m_enabled: 1
     m_path: Assets/Scenes/Credits.unity
   m_HasScriptingDefines: 0
   m_ScriptingDefines: []

--- a/00 Unity Proj/Untitled-26/Assets/Settings/Build Profiles/Windows_DevBuild.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Settings/Build Profiles/Windows_DevBuild.asset
@@ -33,6 +33,8 @@ MonoBehaviour:
   - m_enabled: 1
     m_path: Assets/Scenes/Islands/Flower_Island.unity
   - m_enabled: 1
+    m_path: Assets/Scenes/Islands/Ending.unity
+  - m_enabled: 1
     m_path: Assets/Scenes/Credits.unity
   m_HasScriptingDefines: 0
   m_ScriptingDefines: []

--- a/00 Unity Proj/Untitled-26/Assets/Settings/Build Profiles/macOS.asset
+++ b/00 Unity Proj/Untitled-26/Assets/Settings/Build Profiles/macOS.asset
@@ -33,6 +33,8 @@ MonoBehaviour:
   - m_enabled: 1
     m_path: Assets/Scenes/Islands/Flower_Island.unity
   - m_enabled: 1
+    m_path: Assets/Scenes/Islands/Ending.unity
+  - m_enabled: 1
     m_path: Assets/Scenes/Credits.unity
   m_HasScriptingDefines: 0
   m_ScriptingDefines: []


### PR DESCRIPTION
### Overview
- Pulling a hotfix for ending scene music into dev

### In-depth Details
- When Sky returns to the Mother island at the end of the game, she actually goes to the "Ending" scene in Unity. My music manager script did not have the logic to detect when players transition to this scene previously. 
- Updated MusicManager.cs to include the field and case responsible for playing background music when players return to the mother island 
