### PR TITLE
Fix | Small ice and oasis tweaks

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -15090,7 +15090,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1672679269433873248, guid: 62aa00baa93603c4d81cece31e36d9c3, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.12
+      value: 6.14
       objectReference: {fileID: 0}
     - target: {fileID: 1672679269433873248, guid: 62aa00baa93603c4d81cece31e36d9c3, type: 3}
       propertyPath: m_LocalPosition.z
@@ -15188,7 +15188,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1672679269433873248, guid: 62aa00baa93603c4d81cece31e36d9c3, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.37
+      value: 4.39
       objectReference: {fileID: 0}
     - target: {fileID: 1672679269433873248, guid: 62aa00baa93603c4d81cece31e36d9c3, type: 3}
       propertyPath: m_LocalPosition.z
@@ -100027,7 +100027,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1672679269433873248, guid: 62aa00baa93603c4d81cece31e36d9c3, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.12
+      value: 6.14
       objectReference: {fileID: 0}
     - target: {fileID: 1672679269433873248, guid: 62aa00baa93603c4d81cece31e36d9c3, type: 3}
       propertyPath: m_LocalPosition.z

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -114002,7 +114002,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 91.14
+      value: 72.9
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalPosition.y
@@ -114010,7 +114010,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 100.13
+      value: 118.03
       objectReference: {fileID: 0}
     - target: {fileID: 5209971646417024022, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: m_LocalRotation.w

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -21790,6 +21790,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 410468428}
     - target: {fileID: 5018615782271576797, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 5018615782271576797, guid: 4392a357293f4ce42b6966a489db6a4e, type: 3}
       propertyPath: m_LocalPosition.y
       value: 17
       objectReference: {fileID: 0}
@@ -59882,7 +59886,8 @@ PrefabInstance:
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
       objectReference: {fileID: 7083143465805762537, guid: 6342e50e65c90b54fa63ed40acd73da2, type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5785528264533770188, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
     m_RemovedGameObjects:
     - {fileID: 8147526308312580196, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}
     - {fileID: 4808145769230624831, guid: 690b6fb0a7864c84192e54b90ed456ca, type: 3}

--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Oasis_Island.unity
@@ -36167,7 +36167,7 @@ PrefabInstance:
       objectReference: {fileID: 2029060176}
     - target: {fileID: 2326836619177372947, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: maxHeight
-      value: 48.79
+      value: 48
       objectReference: {fileID: 0}
     - target: {fileID: 2326836619177372947, guid: fee1dd395f6065b4183aec3d2788d1cf, type: 3}
       propertyPath: minHeight


### PR DESCRIPTION
Overview
 - Moved up second ice mountain deathboxes (under parkour)
- Diabled cheat sign on oasis (hot sign was considered a cheat sign)
- Slighlty moved oasis puzzle 1 camera
- Ice crystal is closer to the end of puzzle 4
- Oasis crystal bobs slightly lower/closer to the ground