### PR TITLE
Fixed: Player Rotation During Puzzle using VFX

### DIFF
--- a/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
+++ b/00 Unity Proj/Untitled-26/Assets/Scenes/Islands/Ice_Island.unity
@@ -85147,6 +85147,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1963081915272111325, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 1045250814}
+    - target: {fileID: 1963081915272111325, guid: 1a8a3316ab81bd84499b9ca3304d85a2, type: 3}
       propertyPath: puzzleUI
       value: 
       objectReference: {fileID: 0}

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Game States/ViewManager.cs
@@ -65,6 +65,8 @@ public class ViewManager : MonoBehaviour
     public float fadeInFadeOutInBetween = 0.5f;
     public float currentFadeInFadeOutTime = 0f;
 
+    public GameObject player;
+
     private void Awake()
     {
         
@@ -376,16 +378,20 @@ public class ViewManager : MonoBehaviour
                 }
                 else
                 {
+
+
                     fadePuzzleTransition = false;
                     // Notify GameStateManager that we've detected a puzzle switch.
                     puzzleSwitchDetected.Invoke();
                 }
+
 
             }
 
         }
         else
         {
+            
 
             if (transitionCanvasColor != null && transitionCanvasColor.color.a >= 0)
             {

--- a/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
+++ b/00 Unity Proj/Untitled-26/Assets/Scripts/Player/PlayerFixedMovement.cs
@@ -176,6 +176,7 @@ public class PlayerFixedMovement : MonoBehaviour
     /// <param name="startZ"></param>
     private void MovePlayerToStartTile(int startX, int startZ)
     {
+
         Debug.Log($"PlayerFixedMovement.cs >> Moving Player to the starting tile ({startX},{startZ})...");
         SnapPlayerToTile(startX, startZ);
     }
@@ -574,6 +575,15 @@ public class PlayerFixedMovement : MonoBehaviour
                 TryToMovePlayer(newDeltaX, newDeltaZ);
 
             }
+        }
+
+        if (GameStateManager.CurrentGameState == GameStateManager.GameState.Puzzle)
+        {
+            transform.rotation = Quaternion.Euler(90, 0, 0);
+        }
+        else
+        {
+            //transform.rotation = Quaternion.Euler(0,0,0);
         }
 
     }


### PR DESCRIPTION
Added a line in player fixed movement to check if the game is in puzzle state and if so the player's rotation gets hard set to be 90 degrees in the x axis